### PR TITLE
Fix broken links

### DIFF
--- a/examples/grafana/README.md
+++ b/examples/grafana/README.md
@@ -8,7 +8,7 @@ Both Grafana dashboards provide a high-level picture of the request volume and s
 
 NGINX Service Mesh deploys Grafana and adds `NGINX Mesh Top` as the default dashboard.  If you prefer to use an existing Grafana deployment, you can import either or both example dashboards included in this directory.
 
-## Prerequisties
+## Prerequisites
 - Grafana version >= 6.6.0
 - Prometheus datasource must be [configured](https://prometheus.io/docs/visualization/grafana/#creating-a-prometheus-data-source).
   
@@ -41,4 +41,4 @@ The default NGINX Mesh Top dashboard includes the following stats and graphs:
 
 ## Customizing your own Dashboard
 
-NGINX Service Mesh exposes NGINX Plus metrics in Prometheus format that can be used to create your own panels and custom dashboards. For a list of available metrics, labels, and example Prometheus queries, see the [Traffic Metrics guide](https://docs.nginx.com/nginx-service-mesh/guides/traffic-metrics/).
+NGINX Service Mesh exposes NGINX Plus metrics in Prometheus format that can be used to create your own panels and custom dashboards. For a list of available metrics, labels, and example Prometheus queries, see the [Traffic Metrics guide](https://docs.nginx.com/nginx-service-mesh/guides/prometheus-metrics/).

--- a/examples/prometheus/README.md
+++ b/examples/prometheus/README.md
@@ -36,7 +36,7 @@ port `8887` and the path `/metrics`. All metrics collected from this job are pub
 the
 `nginxplus` namespace. For a list of available metrics, labels, and example
 Prometheus queries, check out the [Traffic
-Metrics](https://docs.nginx.com/nginx-service-mesh/guides/traffic-metrics/)
+Metrics](https://docs.nginx.com/nginx-service-mesh/guides/prometheus-metrics/)
 guide.
 
 


### PR DESCRIPTION
Fix broken links to the Prometheus Traffic Metrics Guide.

Fixes https://github.com/nginxinc/nginx-service-mesh/issues/56