### PR TITLE
Update example otel and prom configs

### DIFF
--- a/examples/otel-collector.yaml
+++ b/examples/otel-collector.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: otel-collector
-        image: otel/opentelemetry-collector:0.55.0
+        image: otel/opentelemetry-collector:latest
         command:
           - /otelcol
           - --config=/conf/otel-collector-config.yaml

--- a/examples/prometheus.yaml
+++ b/examples/prometheus.yaml
@@ -77,12 +77,9 @@ data:
       kubernetes_sd_configs:
       - role: pod
       relabel_configs:
-      - source_labels: [__meta_kubernetes_pod_annotation_nsm_nginx_com_enable_ingress]
+      - source_labels: [__meta_kubernetes_pod_label_nsm_nginx_com_enable_ingress, __meta_kubernetes_pod_label_nsm_nginx_com_enable_egress]
         action: keep
-        regex: true
-      - source_labels: [__meta_kubernetes_pod_annotation_nsm_nginx_com_enable_egress]
-        action: keep
-        regex: true
+        regex: .*true.*
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true


### PR DESCRIPTION
Updated our example prometheus scrape config to the latest version. Also updated otel collector image to the latest, now that this tag is supported. This matches our pattern of latest tags for other example images.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
