### PR TITLE
Restore "v" in version string

### DIFF
--- a/internal/nginx-meshctl/commands/root.go
+++ b/internal/nginx-meshctl/commands/root.go
@@ -177,6 +177,9 @@ Will contact Mesh API Server for version and timeout if unable to connect.`,
 	}
 
 	cmd.Run = func(c *cobra.Command, args []string) {
+		if !strings.HasPrefix(version, "v") {
+			version = "v" + version
+		}
 		// print CLI version
 		fmt.Printf("%s - %s", cmdName, version)
 		if debug {


### PR DESCRIPTION
The "v" before the semver was removed in a previous commit. This is actually still needed.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
