### PR TITLE
Allow fossa job to be manually triggered

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -9,6 +9,7 @@ on:
       - 'docs/**'
       - 'examples/**'
       - '**.md'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.ref_name }}-fossa


### PR DESCRIPTION
Devs should be able to manually trigger fossa job if needed

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
