### PR TITLE
Update linter settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Lint Code
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         with:
-          version: v1.50.1
+          version: v1.51
           args: --timeout 10m
       - name: Lint Helm
         run: helm lint ${{ env.HELM_CHART_DIR }} 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,75 +1,80 @@
-linters:
-  enable-all: true
-  disable:
-    - testpackage
-    - cyclop
-    - exhaustivestruct # [deprecated]
-    - exhaustruct
-    - forbidigo # (forbids use of fmt.Print* in a command line app)
-    - funlen
-    - gci # (errors not fixable by latest gci tool)
-    - gochecknoglobals
-    - gocognit
-    - godox
-    - golint # [deprecated]
-    - gomoddirectives
-    - interfacer # [deprecated]
-    - ireturn
-    - maintidx
-    - maligned # [deprecated]
-    - nestif
-    - scopelint # [deprecated]
-    - tagliatelle
-    - wrapcheck
-    - wsl
-run:
-  timeout: 10m
-  skip-files:
-    - ".*\\.gen\\.go"
-    - "internal/nginx-meshctl/support/printers.go"
 linters-settings:
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 30
-  gci:
-    # put imports beginning with prefix after 3rd-party packages;
-    # only supports one prefix
-    # if not set, use goimports.local-prefixes
+  goimports:
     local-prefixes: github.com/nginxinc/nginx-service-mesh
+  misspell:
+    locale: US
+  revive:
+    ignore-generated-header: true
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: early-return
+      - name: empty-block
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: if-return
+      - name: import-shadowing
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: time-naming
+      - name: unexported-return
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: useless-break
+      - name: var-declaration
+      - name: var-naming
   govet:
     enable:
-      - fieldalignment
+    - fieldalignment
     check-shadowing: true
-  errcheck:
-     ignore: ^Close.*,fmt:.*,github.com/spf13/viper:.*
   lll:
     line-length: 140
-  nakedret:
-    max-func-lines: 0
-  gocritic:
-    enabled-tags:
-      - style
-    disabled-checks:
-      - wrapperFunc
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
+linters:
+    enable:
+    - asciicheck
+    - bodyclose
+    - errcheck
+    - errname
+    - errorlint
+    - gocyclo
+    - godot
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - makezero
+    - misspell
+    - nilerr
+    - noctx
+    - predeclared
+    - reassign
+    - revive
+    - staticcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - wastedassign
+    disable-all: true
 issues:
-  exclude-use-default: false
-  exclude-rules:
-    - text: "G104" # gosec G104 is caught by errcheck
-      linters:
-        - gosec
-    - text: "G107" # Potential HTTP request made with variable url.
-      linters:
-        - gosec
-    # allow passing file perms without variables
-    - text: "mnd: Magic number: 0o[0-7][0-7][0-7], in <argument> detected"
-      linters:
-        - gomnd
-    # ignore false positives from os package
-    - text: "O_(APPEND|CREATE|WRONLY) contains underscore. You should use mixedCap or MixedCap."
-      linters:
-        - nosnakecase
-    # directly contradicts other linters
-    - text: "unnamedResult: consider giving a name to these results"
-      linters:
-        - gocritic
+  max-issues-per-linter: 0
+  max-same-issues: 0
+run:
+  timeout: 5m
+  skip-files:
+  - internal/nginx-meshctl/support/printers.go

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_LINT_VERSION ?= v1.50.1-alpine
+GOLANGCI_LINT_VERSION ?= v1.51-alpine
 
 OUTPUT_DIR = $(shell pwd)/build
 VERSION ?= $(shell git describe --tags)

--- a/internal/nginx-meshctl/commands/commands.go
+++ b/internal/nginx-meshctl/commands/commands.go
@@ -45,7 +45,6 @@ func ReadYes(msg string) error {
 	letter, _, _ := reader.ReadRune()
 	switch letter {
 	case 'Y', 'y':
-		break
 	default:
 		fmt.Println()
 

--- a/internal/nginx-meshctl/commands/deploy.go
+++ b/internal/nginx-meshctl/commands/deploy.go
@@ -620,7 +620,7 @@ func startDeploy(k8sClient k8s.Client, deployer *deploy.Deployer, cleanupOnError
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	signalHandler := newDeploySignalHandle(k8sClient, cleanOnSignal, os.Stdout, deployer.Values.Environment)
+	signalHandler := newDeploySignalHandle(k8sClient, cleanOnSignal, os.Stdout)
 	signalHandler.Watch(ctx, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM)
 
 	// start checking for ImagePullErrors; return when we find an error or successfully connect

--- a/internal/nginx-meshctl/commands/deploy_signal.go
+++ b/internal/nginx-meshctl/commands/deploy_signal.go
@@ -12,28 +12,26 @@ import (
 	"github.com/nginxinc/nginx-service-mesh/pkg/k8s"
 )
 
-type handler func(k8s.Client, os.Signal, io.Writer, string)
+type handler func(k8s.Client, os.Signal, io.Writer)
 
 type deploySignalHandle struct {
-	out         io.Writer
-	handle      handler
-	waitCond    *sync.Cond
-	checked     chan struct{}
-	sigs        chan os.Signal
-	k8sClient   k8s.Client
-	environment string
-	wait        bool
+	out       io.Writer
+	handle    handler
+	waitCond  *sync.Cond
+	checked   chan struct{}
+	sigs      chan os.Signal
+	k8sClient k8s.Client
+	wait      bool
 }
 
-func newDeploySignalHandle(k8sClient k8s.Client, h handler, w io.Writer, env string) *deploySignalHandle {
+func newDeploySignalHandle(k8sClient k8s.Client, h handler, w io.Writer) *deploySignalHandle {
 	return &deploySignalHandle{
-		handle:      h,
-		out:         w,
-		environment: env,
-		waitCond:    sync.NewCond(&sync.Mutex{}),
-		checked:     make(chan struct{}, 1),
-		sigs:        make(chan os.Signal, 1),
-		k8sClient:   k8sClient,
+		handle:    h,
+		out:       w,
+		waitCond:  sync.NewCond(&sync.Mutex{}),
+		checked:   make(chan struct{}, 1),
+		sigs:      make(chan os.Signal, 1),
+		k8sClient: k8sClient,
 	}
 }
 
@@ -42,14 +40,14 @@ func newDeploySignalHandle(k8sClient k8s.Client, h handler, w io.Writer, env str
 // signal will exit the process.
 func (sh *deploySignalHandle) Watch(ctx context.Context, signals ...os.Signal) {
 	go func() {
-		var signalled bool
+		var signaled bool
 		var sig os.Signal
 		signal.Notify(sh.sigs, signals...)
 		defer signal.Stop(sh.sigs)
 		for {
 			select {
 			case sig = <-sh.sigs:
-				if signalled {
+				if signaled {
 					s := fmt.Sprintf("\nExiting immediately on signal %v...\n", sig)
 					_, _ = sh.out.Write([]byte(s))
 
@@ -61,12 +59,12 @@ func (sh *deploySignalHandle) Watch(ctx context.Context, signals ...os.Signal) {
 				sh.wait = true
 				sh.waitCond.L.Unlock()
 
-				signalled = true
+				signaled = true
 				_, _ = sh.out.Write([]byte("\nReceived signal while deploying, waiting for a predictable state before aborting\n"))
 				_, _ = sh.out.Write([]byte("(To exit immediately, press ^C again)\n"))
 			case <-sh.checked:
-				if signalled {
-					sh.handle(sh.k8sClient, sig, sh.out, sh.environment)
+				if signaled {
+					sh.handle(sh.k8sClient, sig, sh.out)
 
 					sh.waitCond.L.Lock()
 					sh.wait = false
@@ -93,7 +91,7 @@ func (sh *deploySignalHandle) Check() {
 	sh.waitCond.L.Unlock()
 }
 
-func cleanOnSignal(k8sClient k8s.Client, sig os.Signal, out io.Writer, environment string) {
+func cleanOnSignal(k8sClient k8s.Client, sig os.Signal, out io.Writer) {
 	_, _ = out.Write([]byte("Cleaning up NGINX Service Mesh after signal...\n"))
 	deleteNamespace := true
 	err := newRemover(k8sClient).remove("nginx-service-mesh", deleteNamespace)

--- a/internal/nginx-meshctl/commands/deploy_signal_test.go
+++ b/internal/nginx-meshctl/commands/deploy_signal_test.go
@@ -33,14 +33,14 @@ var _ = Describe("Signal Handler", func() {
 		sendSig = syscall.SIGUSR2
 		msg = "called in handler"
 
-		handle = func(client k8s.Client, s os.Signal, w io.Writer, _ string) {
+		handle = func(client k8s.Client, s os.Signal, w io.Writer) {
 			defer GinkgoRecover()
 			Expect(s).To(Equal(sendSig))
 
 			_, innerErr := w.Write([]byte(msg))
 			Expect(innerErr).ToNot(HaveOccurred())
 		}
-		signalHandler = newDeploySignalHandle(fakeK8s, handle, buf, "test")
+		signalHandler = newDeploySignalHandle(fakeK8s, handle, buf)
 		Expect(signalHandler).ToNot(BeNil())
 	})
 

--- a/internal/nginx-meshctl/upstreamauthority/upstream_authority.go
+++ b/internal/nginx-meshctl/upstreamauthority/upstream_authority.go
@@ -10,9 +10,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/nginxinc/nginx-service-mesh/pkg/helm"
 	"github.com/xeipuuv/gojsonschema"
 	convert "sigs.k8s.io/yaml"
+
+	"github.com/nginxinc/nginx-service-mesh/pkg/helm"
 )
 
 const (

--- a/internal/nginx-meshctl/upstreamauthority/upstream_authority_test.go
+++ b/internal/nginx-meshctl/upstreamauthority/upstream_authority_test.go
@@ -3,9 +3,10 @@ package upstreamauthority
 import (
 	"os"
 
-	"github.com/nginxinc/nginx-service-mesh/pkg/helm"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/nginxinc/nginx-service-mesh/pkg/helm"
 )
 
 func createFile(filename, contents string) (string, error) {

--- a/pkg/nats/nats_suite_test.go
+++ b/pkg/nats/nats_suite_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
-	mathRand "math/rand"
 	"os"
 	"path/filepath"
 	"testing"
@@ -54,8 +53,6 @@ var _ = BeforeSuite(func() {
 	testFile, err := os.CreateTemp("", "test.pem")
 	Expect(err).ToNot(HaveOccurred())
 	testFilename = testFile.Name()
-
-	mathRand.Seed(time.Now().UTC().UnixNano())
 
 	natsSession = NewSecureNATSSession(testDataDir)
 	natsSession.Start()
@@ -170,7 +167,10 @@ func createTempFile(pattern string) *os.File {
 
 // picks a random port to use for the nats-server.
 func pickPort() int {
-	return 49152 + mathRand.Intn(65535-49152)
+	min := int64(49152)
+	num, err := rand.Int(rand.Reader, big.NewInt(65535-min))
+	Expect(err).ToNot(HaveOccurred())
+	return int(num.Int64() + min)
 }
 
 var testCert = x509.Certificate{


### PR DESCRIPTION
To speed up linting runs and avoid all the deprecations that keep getting added, swapped the behavior of our linter to opt-in to the most important linters. This also aligns with some of our other projects' linting settings.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
