### PR TITLE
Get lingering pod data from k8s instead of mesh

### DIFF
--- a/docs/content/reference/api/api-usage.md
+++ b/docs/content/reference/api/api-usage.md
@@ -334,7 +334,6 @@ These endpoints are for internal use only.
 |Resource Name|REST API Endpoint                       |Description                                                                                                      |CLI Command|Helm Job                |Permissions                             |
 |-------------|----------------------------------------|-----------------------------------------------------------------------------------------------------------------|-----------|------------------------|----------------------------------------|
 |clear        |`/apis/nsm.nginx.com/v1alpha1/clear`    |a POST request to `/clear` turns all NGINX Service Mesh sidecars transparent                                     |remove     |turn-proxies-transparent|create clear in APIGroup nsm.nginx.com  |
-|resources    |`/apis/nsm.nginx.com/v1alpha1/resources`|a GET request to `/resources` returns the list of resources that are injected with the NGINX Service Mesh sidecar|remove     |N/A                     |list resources in APIGroup nsm.nginx.com|
 |version      |`/apis/nsm.nginx.com/v1alpha1/version`  |a GET request to `/version` returns the versions of the control plane components and the sidecars                |version    |N/A                     |list version in APIGroup nsm.nginx.com  |
 
 {{< /bootstrap-table >}}

--- a/internal/nginx-meshctl/support/data.go
+++ b/internal/nginx-meshctl/support/data.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"log"
 	"path/filepath"
-	"strings"
 	"text/template"
 
 	access "github.com/servicemeshinterface/smi-controller-sdk/apis/access/v1alpha2"
@@ -31,6 +30,7 @@ import (
 	nsmspecsv1alpha2 "github.com/nginxinc/nginx-service-mesh/pkg/apis/specs/v1alpha2"
 	"github.com/nginxinc/nginx-service-mesh/pkg/helm"
 	"github.com/nginxinc/nginx-service-mesh/pkg/k8s"
+	podHelper "github.com/nginxinc/nginx-service-mesh/pkg/pod"
 )
 
 const (
@@ -602,7 +602,7 @@ func (df *DataFetcher) writeSidecarInformation() {
 
 		for iter, pod := range pods.Items {
 			// only process this pod if it contains the sidecar
-			if !isInjected(&pods.Items[iter]) {
+			if !podHelper.IsInjected(&pods.Items[iter]) {
 				continue
 			}
 
@@ -871,13 +871,6 @@ Directory containing sidecar information.
 	if err := df.writer.Write(filepath.Join(df.directory, "README.md"), buf.String()); err != nil {
 		log.Printf("- could not write README: %v\n", err)
 	}
-}
-
-// isInjected checks if a pod is injected.
-func isInjected(pod *v1.Pod) bool {
-	val, ok := pod.Annotations[mesh.InjectedAnnotation]
-
-	return ok && strings.ToLower(val) == mesh.Injected
 }
 
 // withHeader adds a banner to separate multiple yamls in the same file.

--- a/internal/nginx-meshctl/support/data_test.go
+++ b/internal/nginx-meshctl/support/data_test.go
@@ -784,21 +784,6 @@ control2   0/1              0          <unknown>   <none>   <none>   <none>     
 		Expect(string(blob)).ToNot(ContainSubstring(`- \<user-namespace\>/`))
 	})
 
-	It("determines if a pod is injected", func() {
-		pod := &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{},
-			},
-		}
-		Expect(isInjected(pod)).To(BeFalse())
-
-		pod.ObjectMeta.Annotations[mesh.InjectedAnnotation] = "not-injected"
-		Expect(isInjected(pod)).To(BeFalse())
-
-		pod.ObjectMeta.Annotations[mesh.InjectedAnnotation] = mesh.Injected
-		Expect(isInjected(pod)).To(BeTrue())
-	})
-
 	It("writes traffic policies", func() {
 		trafficSplit := &splitv1alpha3.TrafficSplit{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/mesh/types.go
+++ b/pkg/apis/mesh/types.go
@@ -69,10 +69,6 @@ const (
 	FileField = "file"
 )
 
-// ProxiedResources is a map of namespace -> k8s resource type -> resource names;
-// used by the CLI to print out proxied resources when removing the mesh.
-type ProxiedResources map[string]map[string][]string
-
 // MetricsConfig holds the data that may be dynamically updated at runtime for the nginx-mesh-metrics component.
 type MetricsConfig struct {
 	PromAddr *string `json:"PrometheusAddress,omitempty"`

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -1,0 +1,80 @@
+// Package pod contains information about a pod resource.
+package pod
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/nginxinc/nginx-service-mesh/pkg/apis/mesh"
+)
+
+const replicaset = "replicaset"
+
+// IsInjected checks if a pod is injected.
+func IsInjected(pod *v1.Pod) bool {
+	val, ok := pod.Annotations[mesh.InjectedAnnotation]
+
+	return ok && strings.ToLower(val) == mesh.Injected
+}
+
+// GetOwner gets a pod's owner type and name.
+func GetOwner(ctx context.Context, k8sClient client.Client, pod *v1.Pod) (string, string, error) {
+	ownerName := pod.Name
+	for _, owner := range pod.GetOwnerReferences() {
+		if owner.Controller == nil || !*owner.Controller {
+			continue
+		}
+		ownerType := strings.ToLower(owner.Kind)
+		ownerName = owner.Name
+		if ownerType == replicaset {
+			var err error
+			// Get the owner replicaset. Retry for 10 seconds if the Get fails.
+			for i := 0; i < 10; i++ {
+				ownerType, ownerName, err = GetReplicaSetOwner(ctx, k8sClient, pod.Namespace, owner.Name)
+				if err != nil {
+					time.Sleep(1 * time.Second)
+
+					continue
+				}
+
+				break
+			}
+			if err != nil {
+				return ownerType, ownerName, fmt.Errorf("unable to determine top-level owner for pod: %w", err)
+			}
+		}
+
+		return ownerType, ownerName, nil
+	}
+
+	return "pod", ownerName, nil
+}
+
+// GetReplicaSetOwner returns a ReplicaSet's owner if it exists, otherwise just return "replicaset".
+func GetReplicaSetOwner(
+	ctx context.Context,
+	k8sClient client.Client,
+	namespace,
+	name string,
+) (string, string, error) {
+	var replicas appsv1.ReplicaSet
+	key := client.ObjectKey{Namespace: namespace, Name: name}
+	err := k8sClient.Get(ctx, key, &replicas)
+	if err != nil {
+		return replicaset, name, fmt.Errorf("error getting replicaset: %w", err)
+	}
+
+	for _, owner := range replicas.GetOwnerReferences() {
+		if owner.Controller != nil && *owner.Controller {
+			return strings.ToLower(owner.Kind), owner.Name, nil
+		}
+	}
+
+	return replicaset, name, nil
+}

--- a/pkg/pod/pod_suite_test.go
+++ b/pkg/pod/pod_suite_test.go
@@ -1,0 +1,14 @@
+package pod_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestType(t *testing.T) {
+	t.Parallel()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Pod Suite")
+}

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -1,0 +1,130 @@
+package pod_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/nginxinc/nginx-service-mesh/pkg/apis/mesh"
+	"github.com/nginxinc/nginx-service-mesh/pkg/pod"
+)
+
+var _ = Describe("Pod", func() {
+	It("determines if a pod is injected", func() {
+		Expect(pod.IsInjected(&v1.Pod{})).To(BeFalse())
+
+		podObj := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					mesh.InjectedAnnotation: "invalid",
+				},
+			},
+		}
+		Expect(pod.IsInjected(podObj)).To(BeFalse())
+
+		podObj.Annotations[mesh.InjectedAnnotation] = mesh.Injected
+		Expect(pod.IsInjected(podObj)).To(BeTrue())
+	})
+
+	Context("gets a pod owner", func() {
+		trueVal := true
+		It("has a replicaset-based owner", func() {
+			podObj := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "ReplicaSet",
+							Name:       "test-replicaset",
+							Controller: &trueVal,
+						},
+					},
+				},
+			}
+			replicaset := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-replicaset",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "Deployment",
+							Name:       "test-deployment",
+							Controller: &trueVal,
+						},
+					},
+				},
+			}
+			k8sClient := fake.NewClientBuilder().WithRuntimeObjects(podObj, replicaset).Build()
+			owner, name, err := pod.GetOwner(context.TODO(), k8sClient, podObj)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(owner).To(Equal("deployment"))
+			Expect(name).To(Equal("test-deployment"))
+		})
+
+		It("has a non-replicaset-based owner", func() {
+			podObj := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "DaemonSet",
+							Name:       "test-daemonset",
+							Controller: &trueVal,
+						},
+					},
+				},
+			}
+			k8sClient := fake.NewClientBuilder().WithRuntimeObjects(podObj).Build()
+			owner, name, err := pod.GetOwner(context.TODO(), k8sClient, podObj)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(owner).To(Equal("daemonset"))
+			Expect(name).To(Equal("test-daemonset"))
+		})
+
+		It("has no owner", func() {
+			podObj := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+				},
+			}
+			k8sClient := fake.NewClientBuilder().WithRuntimeObjects(podObj).Build()
+			owner, name, err := pod.GetOwner(context.TODO(), k8sClient, podObj)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(owner).To(Equal("pod"))
+			Expect(name).To(Equal("test-pod"))
+		})
+	})
+
+	It("gets a replicaset owner", func() {
+		ctlr := true
+		replicas := &appsv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: v1.NamespaceDefault,
+				Name:      "test",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind:       "Deployment",
+						Controller: &ctlr,
+						Name:       "test-deployment",
+					},
+				},
+			},
+		}
+
+		k8sClient := fake.NewClientBuilder().WithRuntimeObjects(replicas).Build()
+		ownerType, ownerName, err := pod.GetReplicaSetOwner(context.TODO(), k8sClient, v1.NamespaceDefault, "test")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ownerType).To(Equal("deployment"))
+		Expect(ownerName).To(Equal("test-deployment"))
+		// remove owner
+		replicas.OwnerReferences = []metav1.OwnerReference{}
+		Expect(k8sClient.Update(context.TODO(), replicas)).To(Succeed())
+
+		ownerType, ownerName, err = pod.GetReplicaSetOwner(context.TODO(), k8sClient, v1.NamespaceDefault, "test")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ownerType).To(Equal("replicaset"))
+		Expect(ownerName).To(Equal("test"))
+	})
+})


### PR DESCRIPTION
To simplify our mesh API server, we can get rid of the calls to the /resources endpoint, in favor of just using the k8s API to get the information we need. This pertains to the list of injected pods that still exist that are printed out when the mesh is removed, for informational purposes.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
