### PR TITLE
Re-enable Openshift upgrades, cleanup code that is no longer needed

### DIFF
--- a/helm-chart/templates/post-delete-hook.yaml
+++ b/helm-chart/templates/post-delete-hook.yaml
@@ -264,12 +264,6 @@ data:
               kubectl delete clusterrole system:openshift:scc:nginx-mesh-spiffe-csi-driver-permissions --ignore-not-found
               kubectl delete rolebinding system:openshift:scc:nginx-mesh-spiffe-csi-driver-permissions --ignore-not-found
               kubectl delete scc nginx-mesh-spiffe-csi-driver-permissions --ignore-not-found
-              # FIXME (sberman): leaving the spire-agent cleanup in for one release as a safety measure
-              kubectl delete daemonset spire-agent --ignore-not-found
-              kubectl delete serviceaccount spire-agent --ignore-not-found
-              kubectl delete clusterrole system:openshift:scc:nginx-mesh-spire-agent-permissions --ignore-not-found
-              kubectl delete rolebinding system:openshift:scc:nginx-mesh-spire-agent-permissions --ignore-not-found
-              kubectl delete scc nginx-mesh-spire-agent-permissions --ignore-not-found
               kubectl delete secret {{ include "registry-key-name" . }} --ignore-not-found
               kubectl delete serviceaccount csi-driver-sentinel --ignore-not-found
               kubectl delete clusterrolebinding csi-driver-sentinel.builtin.nsm.nginx --ignore-not-found
@@ -323,17 +317,7 @@ spec:
             kubectl delete clusterrole system:openshift:scc:nginx-mesh-spiffe-csi-driver-permissions --ignore-not-found
             kubectl delete rolebinding system:openshift:scc:nginx-mesh-spiffe-csi-driver-permissions --ignore-not-found
             kubectl delete scc nginx-mesh-spiffe-csi-driver-permissions --ignore-not-found
-            # FIXME (sberman): leaving the spire-agent cleanup in for one release as a safety measure
-            kubectl delete daemonset spire-agent --ignore-not-found
-            kubectl delete serviceaccount spire-agent --ignore-not-found
-            kubectl delete clusterrole system:openshift:scc:nginx-mesh-spire-agent-permissions --ignore-not-found
-            kubectl delete rolebinding system:openshift:scc:nginx-mesh-spire-agent-permissions --ignore-not-found
-            kubectl delete scc nginx-mesh-spire-agent-permissions --ignore-not-found
           else
-            idx=$(kubectl get daemonset spire-agent -o json | jq '.spec.template.spec.containers | map(.name == "spire-agent") | index(true)')
-            kubectl patch daemonset spire-agent --type=json -p="[{'op': 'remove', 'path': '/spec/template/spec/containers/$idx'}]"
-            idx=$(kubectl get daemonset spire-agent -o json | jq '.spec.template.spec.initContainers | map(.name == "init") | index(true)')
-            kubectl patch daemonset spire-agent --type=json -p="[{'op': 'remove', 'path': '/spec/template/spec/initContainers/$idx'}]"
             {{- if (include "docker-config-json" .) }}
             kubectl get secret {{ include "registry-key-name" . }}
             if [ $? != 0 ]; then

--- a/internal/nginx-meshctl/commands/remove.go
+++ b/internal/nginx-meshctl/commands/remove.go
@@ -164,22 +164,8 @@ func csiDriverRunning(k8sClient k8s.Client, namespace string) bool {
 	defer cancel()
 
 	_, err := k8sClient.ClientSet().AppsV1().DaemonSets(namespace).Get(ctx, "spiffe-csi-driver", metav1.GetOptions{})
-	if err == nil {
-		return true
-	}
 
-	// backwards compatible check if removing an older version of mesh
-	// FIXME (sberman NSM-3113): clean this up after the next release
-	agent, err := k8sClient.ClientSet().AppsV1().DaemonSets(namespace).Get(ctx, "spire-agent", metav1.GetOptions{})
-	if err == nil {
-		for _, c := range agent.Spec.Template.Spec.InitContainers {
-			if c.Name == "set-context" {
-				return true
-			}
-		}
-	}
-
-	return false
+	return err == nil
 }
 
 type remover struct {

--- a/internal/nginx-meshctl/commands/upgrade.go
+++ b/internal/nginx-meshctl/commands/upgrade.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -228,17 +227,9 @@ func (u *upgrader) upgrade(version string) error {
 // - set new version.
 func (u *upgrader) buildValues(ctx context.Context, version string) (map[string]interface{}, error) {
 	// get the previous deployment configuration
-	oldVals, oldValueBytes, err := helm.GetDeployValues(u.k8sClient, "nginx-service-mesh")
+	_, oldValueBytes, err := helm.GetDeployValues(u.k8sClient, "nginx-service-mesh")
 	if err != nil {
 		return nil, fmt.Errorf("error getting old helm values: %w", err)
-	}
-
-	// FIXME (sberman NSM-3113): only here for the 1.6 -> 1.7 release
-	if oldVals.Environment == string(mesh.Openshift) {
-		//nolint:goerr113 // no reason to make this a package level static error as it won't be reused
-		return nil, errors.New("Upgrade command is not supported for OpenShift for 1.7 release.\n" +
-			"See https://docs.nginx.com/nginx-service-mesh/guides/upgrade/#upgrade-to-170-in-openshift " +
-			"for more information on how to upgrade")
 	}
 
 	// copy previous values on top of the new default values


### PR DESCRIPTION
### Proposed changes
There is some logic that was put into place to help with the CSI driver migration from 1.6 to 1.7. Now that 1.7 has released, we can remove this logic.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
