### PR TITLE
remove autoinject annotation from docs

### DIFF
--- a/docs/content/get-started/configuration.md
+++ b/docs/content/get-started/configuration.md
@@ -171,7 +171,6 @@ If not specified, then the global defaults will be used.
 {{% table %}}
 | Annotation                                                                                                                                                        | Values                                 | Default       |
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------|---------------|
-| [injector.nsm.nginx.com/auto-inject]({{< ref "/guides/inject-sidecar-proxy.md#automatic-proxy-injection" >}}) (deprecated, use label instead)                     | `true`, `false`                        | `true`        |
 | [config.nsm.nginx.com/mtls-mode]({{< ref "/guides/secure-traffic-mtls.md#change-the-mtls-setting-for-a-resource" >}})                                             | `off`, `permissive`, `strict`          | `permissive`  |
 | [config.nsm.nginx.com/client-max-body-size](#client-max-body-size)                                                                                                | `0`, `64k`, `10m`, ...                 | `1m`          |
 | [config.nsm.nginx.com/ignore-incoming-ports]({{< ref "/guides/inject-sidecar-proxy.md#ignore-specific-ports" >}})                                                 | list of port strings                   | ""            |


### PR DESCRIPTION
### JIRA
- [NSM-3479: Remove deprecated pod injection annotation](https://nginxsoftware.atlassian.net/browse/NSM-3479)

### Description
The autoinject annotation has been deprecated since 1.6.0 and now should be completely removed from the documentation.