### PR TITLE
Remove global auto-injection

### DIFF
--- a/api/mesh.yaml
+++ b/api/mesh.yaml
@@ -120,7 +120,7 @@ paths:
                 {
                   "op": "replace",
                   "field": {
-                    "isAutoInjectEnabled": false
+                    "loadBalancingMethod": "least_time"
                   }
                 },
                 {
@@ -152,8 +152,7 @@ paths:
                       "prod",
                       "staging"
                 ],
-                  "isAutoInjectEnabled": false,
-                  "loadBalancingMethod": "round_robin",
+                  "loadBalancingMethod": "least_time",
                   "mtls": {
                     "caKeyType": "ec-p256",
                     "caTTL": "720h",
@@ -286,14 +285,10 @@ components:
           enum:
             - "kubernetes"
             - "openshift"
-        isAutoInjectEnabled:
-          type: boolean
-          description: Whether or not automatic injection of the NGINX Service Mesh sidecar is enabled globally.
-          example: true
         enabledNamespaces:
           type: array
-          description: A list of namespaces where automatic injection is enabled. To set this field, the isAutoInjectEnabled field must be false.
-          example: [ ]
+          description: A list of namespaces where automatic injection is enabled.
+          example: ["my-namespace-1", "my-namespace-2"]
           items:
             type: string
         isUDPEnabled:
@@ -644,13 +639,9 @@ components:
               type: string
               description: The address of the Prometheus server. Must be reachable from the Kubernetes cluster that NGINX Service Mesh is installed in.
               example: "prometheus-server.prometheus-namespace.svc.cluster.local:9090"
-            isAutoInjectEnabled:
-              type: boolean
-              description: Whether or not automatic injection of the NGINX Service Mesh sidecar is enabled. This value can be overridden on a per-Pod basis with a Pod annotation.
-              example: true
             enabledNamespaces:
               type: array
-              description: A list of namespaces where automatic injection is enabled. To set this field, the isAutoInjectEnabled field must be false.
+              description: A list of namespaces where automatic injection is enabled.
               example: [ ]
               items:
                 type: string

--- a/helm-chart/configs/mesh-config.conf
+++ b/helm-chart/configs/mesh-config.conf
@@ -10,7 +10,6 @@
     "environment": {{ quote .Values.environment }},
     "isUDPEnabled": {{ .Values.enableUDP }},
     "enabledNamespaces": [{{ range $idx, $elem := .Values.enabledNamespaces }}{{if $idx}},{{end}}{{quote .}}{{ end }}],
-    "isAutoInjectEnabled": {{ not .Values.disableAutoInjection }},
     "loadBalancingMethod": {{ quote .Values.nginxLBMethod }},
     "mtls": {
       "mode": {{ quote .Values.mtls.mode }},

--- a/helm-chart/rancher-files/questions.yaml
+++ b/helm-chart/rancher-files/questions.yaml
@@ -86,11 +86,6 @@ questions:
     - "ec-p384"
     - "rsa-2048"
     - "rsa-4096"
-- variable: disableAutoInjection
-  description: "Disable automatic sidecar injection upon resource creation."
-  label: Disable auto injection
-  type: boolean
-  group: "General Settings"
 - variable: accessControlMode
   description: "Default access control mode for service-to-service communication."
   label: Access control mode

--- a/helm-chart/values.schema.json
+++ b/helm-chart/values.schema.json
@@ -9,11 +9,7 @@
         "mode": {
           "description": "mTLS mode for pod-to-pod communication",
           "type": "string",
-          "enum": [
-            "off",
-            "permissive",
-            "strict"
-          ],
+          "enum": ["off", "permissive", "strict"],
           "default": "permissive"
         },
         "caTTL": {
@@ -36,19 +32,13 @@
         "persistentStorage": {
           "description": "Use persistent storage",
           "type": "string",
-          "enum": [
-            "on",
-            "off"
-          ],
+          "enum": ["on", "off"],
           "default": "on"
         },
         "spireServerKeyManager": {
           "description": "Storage logic for SPIRE Server's private keys",
           "type": "string",
-          "enum": [
-            "disk",
-            "memory"
-          ],
+          "enum": ["disk", "memory"],
           "default": "disk"
         },
         "caKeyType": {
@@ -85,10 +75,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "cert",
-                "key"
-              ]
+              "required": ["cert", "key"]
             },
             "awsPCA": {
               "description": "AWS PCA object",
@@ -133,10 +120,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "region",
-                "certificateAuthorityArn"
-              ]
+              "required": ["region", "certificateAuthorityArn"]
             },
             "awsSecret": {
               "description": "AWS Secret object",
@@ -233,10 +217,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "clientCert",
-                    "clientKey"
-                  ]
+                  "required": ["clientCert", "clientKey"]
                 },
                 "tokenAuth": {
                   "description": "Token authentication object",
@@ -248,9 +229,7 @@
                       "minLength": 1
                     }
                   },
-                  "required": [
-                    "token"
-                  ]
+                  "required": ["token"]
                 },
                 "approleAuth": {
                   "description": "AppRole authentication object",
@@ -272,10 +251,7 @@
                       "default": "approle"
                     }
                   },
-                  "required": [
-                    "approleID",
-                    "approleSecretID"
-                  ]
+                  "required": ["approleID", "approleSecretID"]
                 }
               },
               "required": [
@@ -284,21 +260,9 @@
                 "caCert"
               ],
               "oneOf": [
-                {
-                  "required": [
-                    "certAuth"
-                  ]
-                },
-                {
-                  "required": [
-                    "tokenAuth"
-                  ]
-                },
-                {
-                  "required": [
-                    "approleAuth"
-                  ]
-                }
+                {"required": ["certAuth"]},
+                {"required": ["tokenAuth"]},
+                {"required": ["approleAuth"]}
               ]
             },
             "certManager": {
@@ -330,41 +294,16 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "namespace",
-                "issuerName"
-              ]
+              "required": ["namespace", "issuerName"]
             }
           },
           "oneOf": [
-            {
-              "$ref": "#/definitions/emptyObject"
-            },
-            {
-              "required": [
-                "disk"
-              ]
-            },
-            {
-              "required": [
-                "awsPCA"
-              ]
-            },
-            {
-              "required": [
-                "awsSecret"
-              ]
-            },
-            {
-              "required": [
-                "vault"
-              ]
-            },
-            {
-              "required": [
-                "certManager"
-              ]
-            }
+            {"$ref": "#/definitions/emptyObject"},
+            {"required": ["disk"]},
+            {"required": ["awsPCA"]},
+            {"required": ["awsSecret"]},
+            {"required": ["vault"]},
+            {"required": ["certManager"]}
           ]
         }
       },
@@ -422,41 +361,23 @@
       "oneOf": [
         {
           "properties": {
-            "username": {
-              "$ref": "#/definitions/nonEmptyString"
-            },
-            "password": {
-              "$ref": "#/definitions/nonEmptyString"
-            },
-            "key": {
-              "$ref": "#/definitions/emptyString"
-            }
+            "username": {"$ref": "#/definitions/nonEmptyString"},
+            "password": {"$ref": "#/definitions/nonEmptyString"},
+            "key": {"$ref": "#/definitions/emptyString"}
           }
         },
         {
           "properties": {
-            "key": {
-              "$ref": "#/definitions/nonEmptyString"
-            },
-            "username": {
-              "$ref": "#/definitions/emptyString"
-            },
-            "password": {
-              "$ref": "#/definitions/emptyString"
-            }
+            "key": {"$ref": "#/definitions/nonEmptyString"},
+            "username": {"$ref": "#/definitions/emptyString"},
+            "password": {"$ref": "#/definitions/emptyString"}
           }
         },
         {
           "properties": {
-            "key": {
-              "$ref": "#/definitions/emptyString"
-            },
-            "username": {
-              "$ref": "#/definitions/emptyString"
-            },
-            "password": {
-              "$ref": "#/definitions/emptyString"
-            }
+            "key": {"$ref": "#/definitions/emptyString"},
+            "username": {"$ref": "#/definitions/emptyString"},
+            "password": {"$ref": "#/definitions/emptyString"}
           }
         }
       ],
@@ -470,18 +391,12 @@
     "accessControlMode": {
       "description": "Default access control mode for service-to-service communication",
       "type": "string",
-      "enum": [
-        "allow",
-        "deny"
-      ]
+      "enum": ["allow", "deny"]
     },
     "environment": {
       "description": "Environment to deploy the mesh into",
       "type": "string",
-      "enum": [
-        "kubernetes",
-        "openshift"
-      ]
+      "enum": ["kubernetes", "openshift"]
     },
     "enableUDP": {
       "description": "Enable UDP traffic proxying (beta). Linux kernel 4.18 or greater is required.",
@@ -504,10 +419,7 @@
     "nginxLogFormat": {
       "description": "NGINX log format",
       "type": "string",
-      "enum": [
-        "default",
-        "json"
-      ]
+      "enum": ["default", "json"]
     },
     "nginxLBMethod": {
       "description": "NGINX load balancing method",
@@ -540,18 +452,14 @@
       "items": {
         "type": "string"
       },
-      "default": [ ]
+      "default": []
     },
     "telemetry": {
       "description": "NGINX Service Mesh telemetry settings",
       "type": "object",
       "oneOf": [
-        {
-          "$ref": "#/definitions/telemetryConfig"
-        },
-        {
-          "$ref": "#/definitions/emptyObject"
-        }
+        {"$ref": "#/definitions/telemetryConfig"},
+        {"$ref": "#/definitions/emptyObject"}
       ]
     }
   },
@@ -575,7 +483,7 @@
     "emptyObject": {
       "type": "object",
       "additionalProperties": false,
-      "properties": { }
+      "properties": {}
     },
     "telemetryConfig": {
       "properties": {
@@ -604,28 +512,15 @@
                   "maximum": 65535
                 }
               },
-              "required": [
-                "host",
-                "port"
-              ]
+              "required": ["host", "port"]
             }
           }
         }
       },
-      "required": [
-        "samplerRatio",
-        "exporters"
-      ]
+      "required": ["samplerRatio", "exporters"]
     }
   },
   "anyOf": [
-    {
-      "properties": {
-        "telemetry": {
-          "$ref": "#/definitions/emptyObject"
-        }
-      }
-    },
     {
       "properties": {
         "telemetry": {

--- a/helm-chart/values.schema.json
+++ b/helm-chart/values.schema.json
@@ -9,7 +9,11 @@
         "mode": {
           "description": "mTLS mode for pod-to-pod communication",
           "type": "string",
-          "enum": ["off", "permissive", "strict"],
+          "enum": [
+            "off",
+            "permissive",
+            "strict"
+          ],
           "default": "permissive"
         },
         "caTTL": {
@@ -32,19 +36,30 @@
         "persistentStorage": {
           "description": "Use persistent storage",
           "type": "string",
-          "enum": ["on", "off"],
+          "enum": [
+            "on",
+            "off"
+          ],
           "default": "on"
         },
         "spireServerKeyManager": {
           "description": "Storage logic for SPIRE Server's private keys",
           "type": "string",
-          "enum": ["disk", "memory"],
+          "enum": [
+            "disk",
+            "memory"
+          ],
           "default": "disk"
         },
         "caKeyType": {
           "description": "The key type used for the SPIRE Server CA",
           "type": "string",
-          "enum": ["ec-p256", "ec-p384", "rsa-2048", "rsa-4096"],
+          "enum": [
+            "ec-p256",
+            "ec-p384",
+            "rsa-2048",
+            "rsa-4096"
+          ],
           "default": "ec-p256"
         },
         "upstreamAuthority": {
@@ -70,7 +85,10 @@
                   "type": "string"
                 }
               },
-              "required": ["cert", "key"]
+              "required": [
+                "cert",
+                "key"
+              ]
             },
             "awsPCA": {
               "description": "AWS PCA object",
@@ -115,7 +133,10 @@
                   "type": "string"
                 }
               },
-              "required": ["region", "certificateAuthorityArn"]
+              "required": [
+                "region",
+                "certificateAuthorityArn"
+              ]
             },
             "awsSecret": {
               "description": "AWS Secret object",
@@ -153,7 +174,11 @@
                   "type": "string"
                 }
               },
-              "required": ["region", "certFileArn", "keyFileArn"]
+              "required": [
+                "region",
+                "certFileArn",
+                "keyFileArn"
+              ]
             },
             "vault": {
               "description": "Vault object",
@@ -208,7 +233,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["clientCert", "clientKey"]
+                  "required": [
+                    "clientCert",
+                    "clientKey"
+                  ]
                 },
                 "tokenAuth": {
                   "description": "Token authentication object",
@@ -220,7 +248,9 @@
                       "minLength": 1
                     }
                   },
-                  "required": ["token"]
+                  "required": [
+                    "token"
+                  ]
                 },
                 "approleAuth": {
                   "description": "AppRole authentication object",
@@ -242,14 +272,33 @@
                       "default": "approle"
                     }
                   },
-                  "required": ["approleID", "approleSecretID"]
+                  "required": [
+                    "approleID",
+                    "approleSecretID"
+                  ]
                 }
               },
-              "required": ["vaultAddr", "namespace", "caCert"],
+              "required": [
+                "vaultAddr",
+                "namespace",
+                "caCert"
+              ],
               "oneOf": [
-                {"required": ["certAuth"]},
-                {"required": ["tokenAuth"]},
-                {"required": ["approleAuth"]}
+                {
+                  "required": [
+                    "certAuth"
+                  ]
+                },
+                {
+                  "required": [
+                    "tokenAuth"
+                  ]
+                },
+                {
+                  "required": [
+                    "approleAuth"
+                  ]
+                }
               ]
             },
             "certManager": {
@@ -281,20 +330,52 @@
                   "type": "string"
                 }
               },
-              "required": ["namespace", "issuerName"]
+              "required": [
+                "namespace",
+                "issuerName"
+              ]
             }
           },
           "oneOf": [
-            {"$ref": "#/definitions/emptyObject"},
-            {"required": ["disk"]},
-            {"required": ["awsPCA"]},
-            {"required": ["awsSecret"]},
-            {"required": ["vault"]},
-            {"required": ["certManager"]}
+            {
+              "$ref": "#/definitions/emptyObject"
+            },
+            {
+              "required": [
+                "disk"
+              ]
+            },
+            {
+              "required": [
+                "awsPCA"
+              ]
+            },
+            {
+              "required": [
+                "awsSecret"
+              ]
+            },
+            {
+              "required": [
+                "vault"
+              ]
+            },
+            {
+              "required": [
+                "certManager"
+              ]
+            }
           ]
         }
       },
-      "required": ["mode", "caTTL", "svidTTL", "trustDomain", "persistentStorage", "spireServerKeyManager"]
+      "required": [
+        "mode",
+        "caTTL",
+        "svidTTL",
+        "trustDomain",
+        "persistentStorage",
+        "spireServerKeyManager"
+      ]
     },
     "registry": {
       "description": "NGINX Service Mesh image registry settings",
@@ -330,44 +411,77 @@
         "imagePullPolicy": {
           "description": "Image pull policy",
           "type": "string",
-          "enum": ["Never", "IfNotPresent", "Always"],
+          "enum": [
+            "Never",
+            "IfNotPresent",
+            "Always"
+          ],
           "default": "IfNotPresent"
         }
       },
       "oneOf": [
         {
           "properties": {
-            "username": {"$ref": "#/definitions/nonEmptyString"},
-            "password": {"$ref": "#/definitions/nonEmptyString"},
-            "key": {"$ref": "#/definitions/emptyString"}
+            "username": {
+              "$ref": "#/definitions/nonEmptyString"
+            },
+            "password": {
+              "$ref": "#/definitions/nonEmptyString"
+            },
+            "key": {
+              "$ref": "#/definitions/emptyString"
+            }
           }
         },
         {
           "properties": {
-            "key": {"$ref": "#/definitions/nonEmptyString"},
-            "username": {"$ref": "#/definitions/emptyString"},
-            "password": {"$ref": "#/definitions/emptyString"}
+            "key": {
+              "$ref": "#/definitions/nonEmptyString"
+            },
+            "username": {
+              "$ref": "#/definitions/emptyString"
+            },
+            "password": {
+              "$ref": "#/definitions/emptyString"
+            }
           }
         },
         {
           "properties": {
-            "key": {"$ref": "#/definitions/emptyString"},
-            "username": {"$ref": "#/definitions/emptyString"},
-            "password": {"$ref": "#/definitions/emptyString"}
+            "key": {
+              "$ref": "#/definitions/emptyString"
+            },
+            "username": {
+              "$ref": "#/definitions/emptyString"
+            },
+            "password": {
+              "$ref": "#/definitions/emptyString"
+            }
           }
         }
       ],
-      "required": ["server", "imageTag", "disablePublicImages", "imagePullPolicy"]
+      "required": [
+        "server",
+        "imageTag",
+        "disablePublicImages",
+        "imagePullPolicy"
+      ]
     },
     "accessControlMode": {
       "description": "Default access control mode for service-to-service communication",
       "type": "string",
-      "enum": ["allow", "deny"]
+      "enum": [
+        "allow",
+        "deny"
+      ]
     },
     "environment": {
       "description": "Environment to deploy the mesh into",
       "type": "string",
-      "enum": ["kubernetes", "openshift"]
+      "enum": [
+        "kubernetes",
+        "openshift"
+      ]
     },
     "enableUDP": {
       "description": "Enable UDP traffic proxying (beta). Linux kernel 4.18 or greater is required.",
@@ -376,17 +490,40 @@
     "nginxErrorLogLevel": {
       "description": "NGINX error log level",
       "type": "string",
-      "enum": ["debug", "info", "notice", "warn", "error", "crit", "alert", "emerg"]
+      "enum": [
+        "debug",
+        "info",
+        "notice",
+        "warn",
+        "error",
+        "crit",
+        "alert",
+        "emerg"
+      ]
     },
     "nginxLogFormat": {
       "description": "NGINX log format",
       "type": "string",
-      "enum": ["default", "json"]
+      "enum": [
+        "default",
+        "json"
+      ]
     },
     "nginxLBMethod": {
       "description": "NGINX load balancing method",
       "type": "string",
-      "enum": ["least_conn", "least_time", "least_time last_byte", "least_time last_byte inflight", "random", "random two", "random two least_conn", "random two least_time", "random two least_time=last_byte", "round_robin"]
+      "enum": [
+        "least_conn",
+        "least_time",
+        "least_time last_byte",
+        "least_time last_byte inflight",
+        "random",
+        "random two",
+        "random two least_conn",
+        "random two least_time",
+        "random two least_time=last_byte",
+        "round_robin"
+      ]
     },
     "clientMaxBodySize": {
       "description": "NGINX client max body size",
@@ -397,25 +534,24 @@
       "description": "The address of a Prometheus server deployed in your Kubernetes cluster",
       "type": "string"
     },
-    "disableAutoInjection": {
-      "description": "Disable automatic sidecar injection upon resource creation",
-      "type": "boolean",
-      "default": false
-    },
     "enabledNamespaces": {
       "description": "Enable automatic sidecar injection for specific namespaces",
       "type": "array",
       "items": {
         "type": "string"
       },
-      "default": []
+      "default": [ ]
     },
-    "telemetry":{
+    "telemetry": {
       "description": "NGINX Service Mesh telemetry settings",
       "type": "object",
       "oneOf": [
-        {"$ref": "#/definitions/telemetryConfig"},
-        {"$ref": "#/definitions/emptyObject"}
+        {
+          "$ref": "#/definitions/telemetryConfig"
+        },
+        {
+          "$ref": "#/definitions/emptyObject"
+        }
       ]
     }
   },
@@ -439,7 +575,7 @@
     "emptyObject": {
       "type": "object",
       "additionalProperties": false,
-      "properties": {}
+      "properties": { }
     },
     "telemetryConfig": {
       "properties": {
@@ -468,32 +604,20 @@
                   "maximum": 65535
                 }
               },
-              "required": ["host", "port"]
+              "required": [
+                "host",
+                "port"
+              ]
             }
           }
         }
       },
-      "required": ["samplerRatio", "exporters"]
+      "required": [
+        "samplerRatio",
+        "exporters"
+      ]
     }
   },
-  "allOf": [
-  {
-    "if": {
-      "properties": {
-        "disableAutoInjection": {
-          "const": false
-        }
-      }
-    },
-    "then":{
-      "properties": {
-        "enabledNamespaces": {
-          "$ref": "#/definitions/emptyArray"
-        }
-      }
-    }
-  }
-],
   "anyOf": [
     {
       "properties": {
@@ -524,7 +648,6 @@
     "environment",
     "nginxErrorLogLevel",
     "nginxLogFormat",
-    "nginxLBMethod",
-    "disableAutoInjection"
+    "nginxLBMethod"
   ]
 }

--- a/helm-chart/values.schema.json
+++ b/helm-chart/values.schema.json
@@ -520,22 +520,6 @@
       "required": ["samplerRatio", "exporters"]
     }
   },
-  "anyOf": [
-    {
-      "properties": {
-        "telemetry": {
-          "$ref": "#/definitions/emptyObject"
-        }
-      }
-    },
-    {
-      "properties": {
-        "telemetry": {
-          "$ref": "#/definitions/telemetryConfig"
-        }
-      }
-    }
-  ],
   "required": [
     "mtls",
     "registry",

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -57,12 +57,7 @@ nginxLBMethod: "least_time"
 # Setting to "0" disables checking of client request body size.
 clientMaxBodySize: "1m"
 
-# Globally disable automatic sidecar injection upon resource creation.
-# Use either "enabledNamespaces" or a namespace label to enable automatic injection.
-disableAutoInjection: false
-
 # Enable automatic sidecar injection for specific namespaces.
-# Must be used with "disableAutoInjection".
 enabledNamespaces: []
 
 # The address of a Prometheus server deployed in your Kubernetes cluster.

--- a/internal/nginx-meshctl/commands/deploy.go
+++ b/internal/nginx-meshctl/commands/deploy.go
@@ -56,13 +56,13 @@ This command installs the following resources into your Kubernetes cluster by de
 
       nginx-meshctl deploy ... --namespace my-namespace
 
-  - Deploy the Service Mesh with mTLS and automatic injection turned off:
+  - Deploy the Service Mesh with mTLS turned off:
 
-      nginx-meshctl deploy ... --mtls-mode off --disable-auto-inject
+      nginx-meshctl deploy ... --mtls-mode off
 
-  - Deploy the Service Mesh and only allow automatic injection in namespace "my-namespace":
+  - Deploy the Service Mesh with automatic injection enabled for my-namespace-1 and my-namespace-2:
 
-      nginx-meshctl deploy ... --disable-auto-inject --enabled-namespaces="my-namespace"
+      nginx-meshctl deploy ... --enabled-namespaces "my-namespace-1,my-namespace-2"
 
   - Deploy the Service Mesh and enable telemetry traces to be exported to your OTLP gRPC collector running in your Kubernetes cluster:
       
@@ -203,18 +203,11 @@ func Deploy() *cobra.Command {
 	if err != nil {
 		fmt.Println("error marking flag as hidden: ", err)
 	}
-	cmd.Flags().BoolVar(
-		&values.DisableAutoInjection,
-		"disable-auto-inject",
-		defaultValues.DisableAutoInjection,
-		`disable automatic sidecar injection upon resource creation
-		Use the --enabled-namespaces flag to enable automatic injection in select namespaces`)
 	cmd.Flags().StringSliceVar(
 		&values.EnabledNamespaces,
 		"enabled-namespaces",
 		defaultValues.EnabledNamespaces,
-		`enable automatic sidecar injection for specific namespaces
-		Must be used with --disable-auto-inject`,
+		"enable automatic sidecar injection for specific namespaces",
 	)
 	cmd.Flags().StringVar(
 		&values.PrometheusAddress,
@@ -532,10 +525,6 @@ func validateInput(values *helm.Values, registryKeyFile string) error {
 
 	if registryKeyFile != "" && values.Registry.Username != "" {
 		return fmt.Errorf("%w: cannot set both --registry-key and --registry-username/--registry-password", errInvalidConfig)
-	}
-
-	if !values.DisableAutoInjection && len(values.EnabledNamespaces) > 0 {
-		return fmt.Errorf("%w: enabled namespaces should not be set when auto injection is enabled", errInvalidConfig)
 	}
 
 	return nil

--- a/internal/nginx-meshctl/commands/deploy_test.go
+++ b/internal/nginx-meshctl/commands/deploy_test.go
@@ -257,10 +257,6 @@ var _ = Describe("Deploy", func() {
 			values.Registry.Password = password
 			runTest(values, "key-file", "cannot set both --registry-key and --registry-username/--registry-password")
 		})
-		It("makes sure enabled namespaces aren't provided when injection is enabled", func() {
-			values.EnabledNamespaces = []string{"ns"}
-			runTest(values, "", "invalid configuration: enabled namespaces should not be set")
-		})
 		It("passes if everything is valid", func() {
 			values.Registry.Username = user
 			values.Registry.Password = password

--- a/internal/nginx-meshctl/commands/services.go
+++ b/internal/nginx-meshctl/commands/services.go
@@ -140,9 +140,7 @@ func isNamespaceInjectionEnabled(ctx context.Context, k8sClient client.Client, n
 		fmt.Printf("error getting namespace: %v\n", err)
 		return false, err
 	}
-	return slices.Contains(*meshConfig.EnabledNamespaces, ns) ||
-		nsObj.GetLabels()[mesh.AutoInjectLabel] == mesh.AutoInjectionEnabled ||
-		(*meshConfig.IsAutoInjectEnabled && !(mesh.IgnoredNamespaces[ns])), nil
+	return slices.Contains(*meshConfig.EnabledNamespaces, ns) || nsObj.GetLabels()[mesh.AutoInjectLabel] == mesh.AutoInjectionEnabled, nil
 }
 
 // getMeshConfig fetches the mesh.MeshConfig of the mesh using the mesh.MeshClient.

--- a/internal/nginx-meshctl/commands/upgrade.go
+++ b/internal/nginx-meshctl/commands/upgrade.go
@@ -325,7 +325,6 @@ func (u *upgrader) savePreviousConfig(meshConfig mesh.MeshConfig) {
 	u.values.MTLS.CATTL = *meshConfig.Mtls.CaTTL
 	u.values.MTLS.SVIDTTL = *meshConfig.Mtls.SvidTTL
 	u.values.MTLS.Mode = string(*meshConfig.Mtls.Mode)
-	u.values.DisableAutoInjection = !*meshConfig.IsAutoInjectEnabled
 	u.values.EnabledNamespaces = *meshConfig.EnabledNamespaces
 	u.values.ClientMaxBodySize = meshConfig.ClientMaxBodySize
 

--- a/internal/nginx-meshctl/commands/upgrade_test.go
+++ b/internal/nginx-meshctl/commands/upgrade_test.go
@@ -47,7 +47,6 @@ func createMeshConfigMap(client kubernetes.Interface, namespace string) {
 		"name": "should-not-change",
 		"image": "nginx-mesh-init:old"
 	},
-	"isAutoInjectEnabled": true,
 	"enabledNamespaces": [],
 	"loadBalancingMethod": "round_robin",
 	"accessControlMode": "deny",

--- a/internal/nginx-meshctl/deploy/deploy_test.go
+++ b/internal/nginx-meshctl/deploy/deploy_test.go
@@ -141,13 +141,11 @@ var _ = Describe("Deploy", func() {
 
 		It("validates telemetry fields", func() {
 			values := &helm.Values{
-				DisableAutoInjection: true,
 				Telemetry: &helm.Telemetry{
 					SamplerRatio: 5.0,
 				},
 				Tracing: nil,
 			}
-			values.DisableAutoInjection = true
 			values.EnabledNamespaces = []string{"default"}
 			deployer.Values = values
 			_, err := deployer.Deploy()

--- a/pkg/apis/mesh/mesh.gen.go
+++ b/pkg/apis/mesh/mesh.gen.go
@@ -189,14 +189,11 @@ type MeshConfig struct {
 	// ClientMaxBodySize The maximum allowed size of the client request body.
 	ClientMaxBodySize string `json:"clientMaxBodySize"`
 
-	// EnabledNamespaces A list of namespaces where automatic injection is enabled. To set this field, the isAutoInjectEnabled field must be false.
+	// EnabledNamespaces A list of namespaces where automatic injection is enabled.
 	EnabledNamespaces *[]string `json:"enabledNamespaces,omitempty"`
 
 	// Environment The environment that the NGINX Service Mesh control plane is installed in.
 	Environment MeshConfigEnvironment `json:"environment"`
-
-	// IsAutoInjectEnabled Whether or not automatic injection of the NGINX Service Mesh sidecar is enabled globally.
-	IsAutoInjectEnabled *bool `json:"isAutoInjectEnabled,omitempty"`
 
 	// IsUDPEnabled Enable UDP traffic proxying.
 	IsUDPEnabled bool `json:"isUDPEnabled"`
@@ -292,11 +289,8 @@ type PatchConfig struct {
 		// ClientMaxBodySize The maximum allowed size of the client request body.
 		ClientMaxBodySize *string `json:"clientMaxBodySize,omitempty"`
 
-		// EnabledNamespaces A list of namespaces where automatic injection is enabled. To set this field, the isAutoInjectEnabled field must be false.
+		// EnabledNamespaces A list of namespaces where automatic injection is enabled.
 		EnabledNamespaces *[]string `json:"enabledNamespaces,omitempty"`
-
-		// IsAutoInjectEnabled Whether or not automatic injection of the NGINX Service Mesh sidecar is enabled. This value can be overridden on a per-Pod basis with a Pod annotation.
-		IsAutoInjectEnabled *bool `json:"isAutoInjectEnabled,omitempty"`
 
 		// LoadBalancingMethod The global load balancing method for Services in NGINX Service Mesh. This value can be overridden on a per-Service basis with a Service annotation.
 		LoadBalancingMethod *PatchConfigFieldLoadBalancingMethod `json:"loadBalancingMethod,omitempty"`
@@ -919,78 +913,77 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xce4/bOJL/KoRu/5jBud3uV5Ju4HDoSbKZRtIZI3FuDkhyC1oqW9xIpJaknPbM9nc/",
-	"VFGiXpTtzmRu5wbJX22JIuvFql8Vi/k1ilVeKAnSmujq10iDKZQ0QD9+4Mkb+EcJxuKvWEkLkv7kRZGJ",
-	"mFuh5PHfjZL4DO54XmTgRiYQXT1+cnk6iXIwhq8huoqE3PBMJCxWciXWpabPrxhIvswgYZLnYAoeg2Em",
-	"VWWWMKksWwIzYNnnFCTjpVVMyL9DjF8yYepvo/tJZOIUco6r/0XDKrqK/u244ezYvTXHz7VW+lYlkEX3",
-	"9/eTKAETa1HgfNEV8suELErLCq55Dhb0hCnNSmnKolDaQo/6KXsDVm8ZX1nQjCeJBmOEXHdHMWFMCThR",
-	"nEL8Cd+vlGZ2WygzRdr/qvRSJAnILxTzWVvMq3qyK1Ya0CgmFCQvbaq0+OXrSWuRAtPOPNiKC9RhUgIj",
-	"HZlytRKxAGlZocVGZLAGM/0gce0baUFLnr0FvQFNa3wh35dtvmNvM2uwbK5QVVnmbOX3YDnmsjLQQqsY",
-	"jIGELSHmpQGmVoxLJipGmSFOGeDcpPB3sqWOL+P9SZv3sjXfFcv5J2Cm1MC2qmRcAykfpMV5IWGfhU2Z",
-	"TYG9LJegJVgw7Hp+U5H5tWT1Do2vtXC1ZWsvoDTLBW0WMgu/KDme6/nNU9pB+GOogu7uUiti5vWLm9f/",
-	"zdCoRAzsFkyKTE2jSVRoVYC2wjm1apeGZ25J5Nnrt+ST9s/v1RPJtZB3RzmY9IgXYtr8jCaR3RY4xFgt",
-	"5BqFjErnQoKeK21HGXVDGHqfB1Dy5Pz8zC+Jdrh2ii1Gl3rgAsH57ycR7g6h0arfe0lXy/Y5/ugnUEv0",
-	"6UgfmdQzsFxkSGZXcx2i+zxcs4Q+g8TtM1btDqbBllri5twSc87Kpx/kB7lIwUA90NTSplErlWXqM7pq",
-	"IVdK52RqE4xDuJ3cHl1mcIXTHLGfU25ZyosCJCRT92TLxOAZtzR5jBH2HyVIDHa4P78T6DC239OwNxCr",
-	"PAeZQMK4C3VWMYub2iqmwahsAzQPxRXcPm0bJBGyRCHtH8rZ7Cx2k9DfcFU908CNkhSHSFzu7ZQtUmHQ",
-	"tbEMeILrueGFQv8keNah3X+kt4GlwtQOd0LPatpqHTUR53UGFuK849A0ZJmDFnFlGTiKWVQGMroEjJPE",
-	"q0iQydXWjTMknSrys6LUhTIuiLXEfXJ6dn7x6HForzl7JLqEhdwc5E4r27/3E3Kt+RZ/e28/ZC8tcy6P",
-	"NPAEbbI26AkTkj2X60yYdOL4dR8uwZBCXDx6kPnsV19N5sQpI6jBO8JS2jQ+nieJwFV4Nm8pdMUzA5ND",
-	"AgDUU6IaDciEWcggJ3CWcMuZVUh6LmR7/pN+bFA2K/ap6SebFTUHFQP39wEub/JKWw/g7brl8UVOOkQK",
-	"tEADrUAFPnaBicuk+mn5ehjoRB40F5Sf5eva19OobhQ7mZ5NZ6GIhauGJ2wHysCMiYo/gT7SsBbG6q0L",
-	"jNNY5cfS5MetqGlEAjHXe62MKJlULIZsDIPWGIT4UWUJevt8KWQf0bN6FfJepRyLh6gnrTJWZFzCB4mq",
-	"wJFka/TM7ase9IgRJz51n94GfRUK0w3zS+TortQqQAUJWZY5BVuMVxEalNyiRBrh128G6uSF2GfsDRDD",
-	"8aVVN5R+qR2YhbylrUMdfoPBM24lbp9hmSr1iS2FTEy1Mz25lyPIJc4wm7jldz+oZPtW/DIiu5zfibzM",
-	"GTENCTPiF2+YbgoP4Jcq2fYMP0eVcYuwPbqK/ufDh+Tf3396md+uX3z8z7+ERFgloK997hpyz5kwBK1a",
-	"GW6FIwLCabLaKVsoSn4txuSVgCyZVIH02mvieZU902uWl4YyEnIuHd7ef5w0UWjARj/WgNwIrWRe5SRD",
-	"MbcGNLret00c/DeWZ0ixkG3z/eSBdzSJVAHSpGJlu4bcGTPgISCVIe0/p2BT0Jh9VEnxQAHjGLhyTi0V",
-	"sXWmljzLunZkdQmewKVSGXDpKHz3bD5KmnvB3j2bM6s5ps+YWN5tMUNqz14FjuH0meLJDzzjMhZyfQs2",
-	"VUlYeY5ohuPZsv6A5fQFYZ6Ka9RWyOs4kLjhWQk1glIb0JqqDkxJxlkB+qj+ZsmNMC7p5H4iSp5dDaVl",
-	"BVqVMvmbVkuBzjMDbuzfYiWbH1aQ329+sAz/Wm7t2GPE75lYp5h/aC4Tlfs/mP2sOj9YZ8XB82rx4PP/",
-	"aOjo2Gzny4HN5jbbCwtvbWYaH+x9yHgcpteVh3nwthzLZ4NwAN8SXnyl1q9g4xB5wFkQpMzUmmU46IAd",
-	"hoYvwLRNI4FlucaQL1eoNKmsiFGmn7kmAEtlpEkUa4Ga5hlQxgk56HVXI9UHYW5eqfVfKdsLc4I8uGzw",
-	"S5lY8TJDwqi006GreTcgrdAKdyeU5npX8aLKt2vS5v6rugCVQJGpLTrtrpqb+Vsli6nZxNM4K40FPc1U",
-	"zLOry9nlbIS+u+0+O57joMaQayz4EravD4KV9QfsE2xdzBHGZ25FmWVj+nDg08FS02U8xEylPg/fd/Hk",
-	"BrU+ksI+7EOfpuz7YlEPbERodWnsM5VzIUdgPg5gCY0YN9iuSKq/pkqv96JwBJC19tuuqQsgeoGvJ+GA",
-	"7AJIcxLAzqF90RXK0Moql4tupIr3UVsH4SAa9HQDhxGCqMHMpPHnvzXxxVidL169HeZ+MX8J2wUtHTIM",
-	"2kLboqp80GFECuzt/ObNc+bK8uzpddtxQXxUnF48wifxUXH25Bxla/jR6ez8SfXn+ezyUdejNR8Na598",
-	"sXgVpu3p9bERa4mQBMlcLF4hDElVqc136fdTditkhT1Oz9Mpu+V31c9L+tcz58ens7QL6k/ez44uP/56",
-	"Orm4/y79/p+n78+PLj+6v/CFe3tSvX1/1n8UTAPy0VwO1XNgBqdWK6QUNNXFN7Q1rBZxDwV3Bgy910Yk",
-	"o6JFWaoVi9FOVnQYYFxVjnzoZ6U/ofmbtrxdnV6WFsx3+fdtcQtTSbyXQ/XE/f7ES3BGEvxnHpJhqIIS",
-	"qLR8jR3DJftp8WrO1m/mT33haLiFUmVGUAC+qd3pTwVI75q7U6JMEUpCbJvy0yuQa5tS6WkYRg8qzj9s",
-	"RZcOR1ePLi7OLogC93u2t3pP/FdEhfzYnNs4/VoVPJrVRfWUqjPIaVkkZKJWYYqR84RKyuOQtnUuO9Am",
-	"5cd76fzXlWuGHvJ3q3d8K3D8a4oFh+bNc5V0c2Z80MuX95UavtUC/jC1gK+R9P8/SrT/IHn175VDT9lt",
-	"5YI08Dilkt1Kowl0uweqxNmFtAAzoVJoIB8/qlZtPfFO9gEJ+pdnmSFcpoqRdBMzCrViGEN5fW69BHQA",
-	"qFxI0B8cFL7Zf6FDIZ9zyPja8/AkgWTCNORqg38ozTQUGY+rulYde5OEUkMcRX/QkIDV9BCRKqJJBSSC",
-	"gEhpa3a1rSCUMjvL5T0Tp8BKbjRwuidjlSOVwaXqt+zHxWJOC3fbQ548eRI6ZKk/e6GLeM/EBDwDE1+e",
-	"7Jt43iQwBy7h2v9sP52ibo6WxLa4qwhPKNZkSX36znbR91rZG/kSthue7SGuOeZKuUwyMDXOMs4f+LiJ",
-	"0GHUjrvEXc52Enew4LzSv6rgZrtoewOJ0LgRdlOmq2HOchx4IELrFy0xWsW4VITAXP4jA4QvuWn8SqGV",
-	"VbHKmpIhTdUX8k4LXcTFHh4WT0M76nJ2vmfaZwj190+NGcFAPAlI9Af4vj4cEismrO/uZAV3KWLAqyiN",
-	"g22TqlRZVAui0hwuheizdbGHrYOtspbblxllyCYvZ493Efcu2afKd8/CqrwMTYtxUcQjuKEFFKpxQa8b",
-	"pFeVdq1GXXn9dtyVX+6a9JmDRs/X45jHr+DPHVFL1BpGX/nnXnHOyOZZadiNdGOqNDlzHcfupAESxg3j",
-	"sp4n9mP6vuV8Fwvj0chTPhqNTndNvNfb+/m9RBIwVkhCHVUo5xr2bsG+fe2karcr9ST9IVzpbBcjo67U",
-	"8zDmSh/tmnZ0W/tpx7Z1EPMUWWmuXSfMSOGtro+3rP56flOJ/Hp+4x0oeVeBKYEqLQr3gGzGN3z1d3VQ",
-	"BrVufwSe2XSsCWdoCeQ7UvoIVbsEHwRa/eajtFxeHEYLrvL2cILe/gaKHu2tX3qv2nMk4e0f2H5dQx7z",
-	"qE24iYJIrQeqR6FwGIMGAFYXqgwRxlhw7m6gbpRsdkET5oLGNq71YEbUOvL9TY38gdS/mw1RarX3BLqV",
-	"oNHxKZem4DrY5NSr/R2Yr2Es0KWUrm+ctVYgmDNli94TlgOXrZwwNGHB3Z0iSye6LhLbVKtyndZbphWV",
-	"qLimSkvbaIvfcbllusyaDVZNckhXUW9POTF3RRdSfL+M8DWObXwNY6h93/27t8W613l8P4kMCUC/wYVG",
-	"YgDoGKTla+fONdW3fehvLv9wmdQnMYkXtT+oWfL4E0hC16uqEhatMkUHx/6U5iR4QiPLfFk5uJ6k7++r",
-	"Ot2A8HcGdlzlqA6KSMKhMRNX0q8faTCq1J5txDkiFgWniqpD8vQRdcHWV/TYVpW6XRJrZvEXkPZsqS3d",
-	"0qhuE/x8/eb1zesXV2wxzhZV1dgSLGcaMuAGmLHclsb1SrswrVv3K9CwSkNsuNMS6kD2pX4lp8wTQBCD",
-	"BG98I33C3DmHBmbK6hBLsTjlcg2IfZFJJAw2KtuAmbLXiq1Lrrm0QOaEZvGZa9ePXHArliITlnKfnCdV",
-	"F7EVluqCYa6jSbQBbZzeNyc8K1J+4up0IKnHNzqbzqiju+A2pU1yHPuNuYaA+3tDl2ZMfVtleFRX93r7",
-	"GmYY9PpS4E0SXUUvwFYbb9K9aHo6mz3sGlzgaM4fqVVtzf6e185bWb1LWO7elDuIPT8/CzY9uw7lwPmc",
-	"6x/u9M52e1aDpzK9g476dKDVwdFqpKj6Juq2Btd3ULcJtE7/o5O01y3Y7eULnSj4in+vYN+qrgeK6J3m",
-	"MZMf5UoKq7SQ66nZxHVF2neI+UDd1C9dMbJbenR1xLGqoaviBWt2roYWqpi5CtawXuUKQp3yjyvmDEo3",
-	"rhgyUvpwxYhO6cEVEnzZwKX/TbLvMveRPN3lxN0M2KWzweTV5ZTDDNKlaJ2EzKVXnWTKpUY+EXLJRyjV",
-	"cKnAKPBHXN4HVhThQ/1+UTTstauurDz4vsjVyfSCHJy7oRIFbpSMNOk9eEUhhd2xHL4enLh08El9x8j1",
-	"l0TKQnZU3VRWOrCFIu+Pzk4e3w8Qy2w6O+n3Anaa+A6+ztu6MhO4zvu2JJe7KrNsyzTaNGwgOex4xsUM",
-	"uvl8PjsZo8NHhOPO9Wj66Gz/R80l+vtJdOECyu4vQhfRScBlnnPUHAasvdxFk+juaHVxBHcFaIFuHzek",
-	"1SVafcFtnAbQWd3Z8hDp9aNpuwHHwXQwFqPRQ0Lp+1ZrTLApot6/qsBQVR2V3U9anwVaRN6jw6dWT8vX",
-	"6Ow+1jPwJInuP7ZNUkn4aUWE7MzdWszi6gfdqOx+1GsC+Rgw8mewEhIG3Ud5dff2IeoiuFjPUZ1PGkz7",
-	"uGGcYUKXASMCmaPQIyvqUCMiEWUFhlD+26Rllan9iQHVAfa1E3eNG/Y3TPYNk33DZN8w2Z8Ak7lY8yWI",
-	"7ACo1PqfoP6vQFwHiDnAFOLr6cFYbOwNLkQI0BAK6TW3+v8Xh87HoklUavTLx7wQBu2wZZVN7eXj/f8G",
-	"AAD////gs4hYSwAA",
+	"H4sIAAAAAAAC/+xce3PbOJL/Kije/jFTJ8nyK4lddXXlSbIZV2KPynFursrJbUFkS8SaBLgAqFgz6+9+",
+	"1Q0S4gOU5EzmLneV/GWReDT6+etGM79HscoLJUFaE53/HmkwhZIG6MdPPLmBf5RgLP6KlbQg6U9eFJmI",
+	"uRVKHvzdKInP4IHnRQZuZALR+fMXZ0ejKAdj+BKi80jIFc9EwmIlF2JZapp+zkDyeQYJkzwHU/AYDDOp",
+	"KrOESWXZHJgByz6nIBkvrWJC/h1inMmEqedGj6PIxCnkHHf/i4ZFdB79y8HmZAfurTl4rbXSVyqBLHp8",
+	"fBxFCZhYiwLXi87xvEzIorSs4JrnYEGPmNKslKYsCqUtdKifsBuwes34woJmPEk0GCPksj2KCWNKwIXi",
+	"FOJ7fL9Qmtl1ocwEaf+r0nORJCC/kM3HTTYv6sXOWWlAI5uQkby0qdLit6/HrdsUmHbqwRZcoAyTEhjJ",
+	"yJSLhYgFSMsKLVYigyWYyUeJe19KC1ry7D3oFWja4wvPfdY8d+x1ZgmWzRSKKsucrvwZR465rBS00CoG",
+	"YyBhc4h5aYCpBeOSieqgzNBJGeDaJPAPsiGOLzv7i+bZy8Z65yzn98BMqYGtVcm4BhI+SIvrQsI+C5sy",
+	"mwJ7W85BS7Bg2MXssiLza/HqAypfY+PKZGsvoDTLBRkLqYXflBzPxezyJVkQ/uiLoG1dakGHuX5zef2f",
+	"DJVKxMCuwKR4qEk0igqtCtBWOKdWWWl45QZHXl2/J5+0e30vnkguhXwY52DSMS/EZPMzGkV2XeAQY7WQ",
+	"S2QyCp0LCXqmtB08qBvC0Ps8gZIXJyfHfkvUw6UTbDG41RM3CK7/OIrQOoRGrb7znK627Z74k19AzdGn",
+	"I32kUq/AcpEhmW3JtYjunuGCJTQNEmdnrLIOpsGWWqJxrulwTssnH+VHeZuCgXqgqblNoxYqy9RndNVC",
+	"LpTOSdVGGIfQnJyNzjM4x2XG7NeUW5byogAJycQ9WTPRe8YtLR5jhP1HCRKDHdrnDwIdxvpHGnYDscpz",
+	"kAkkjLtQZxWzaNRWMQ1GZSugdSiuoPk0dZBYyBKFtH8sp9Pj2C1Cf8N59UwDN0pSHCJ2ubcTdpsKg66N",
+	"ZcAT3M8NLxT6J8GzFu1+kl4HtgpT27eEjtY0xTqoIs7r9DTEece+asgyBy3iSjNwFLMoDDzoHDBO0llF",
+	"godcrN04Q9ypIj8rSl0o44JYg92HR8cnp8+eh2zN6SPRJSzkZi93Wun+o1+Qa83X+Nt7+/7x0jLncqyB",
+	"J6iTtUKPmJDstVxmwqQjd143cQ6GBOLi0ZPUZ7f4ajJHThhBCT4QltJm4+N5kgjchWezhkAXPDMw2icA",
+	"QL0kitGATJiFDHICZwm3nFmFpOdCNtc/7MYGZbNil5h+sVlRn6A6wONj4JSXeSWtJ5ztouHxRU4yRAq0",
+	"QAWtQAU+doGJy6T6afmyH+hEHlQX5J/ly9rX06h2FDucHE+moYiFu4YXbAbKwIqJiu9BjzUshbF67QLj",
+	"JFb5gTT5QSNqGpFAzPVOLSNKRtURQzqGQWsIQvyssgS9fT4XsovoWb0Lea9SDsVDlJNWGSsyLuGjRFHg",
+	"SNI1eubsqgM9YsSJL93Uq6CvQma6YX6LHN2VWgSoICbLMqdgi/EqQoWSa+TIhvn1m544eSF2KfsGiOH4",
+	"0qpLSr/UFsxC3tLWoQ7nYPCMG4nbZ5inSt2zuZCJqSzTk3s2gFziDLOJK/7wk0rW78VvA7zL+YPIy5zR",
+	"oSFhRvzmFdMt4QH8XCXrjuLnKDJuEbZH59F/ffyY/Ovd/dv8avnm07//JcTCKgG99rlryD1nwhC0amS4",
+	"FY4IMGeT1bZou4vy9dgvMD5EZ9Z8cIQy92GmR2c3mIBcCa1kXiUdfT42BmyEucsOHL43lmcIw4Rs6ue9",
+	"R9bRKFIFSJOKhW1ramtM7wzCfHg1e11l/D2i3Qv24dWMWc0x+8S87GGNCUaTkZXfrVafK5UBp/wwUzz5",
+	"iWdcxkIur8CmKgmzZpmpOc8YjmfzegLLaQZBhopByIuQ0TqMteJZCTUAUSvQmpJ2piTjrAA9rufMuRHG",
+	"5WzcL0S5pytBNHisVSmTv2k1F+h7MuDG/i1WcvPDCnKbmx8sw7/mazv0GOFvJpYpwnfNZaJy/wezn1Xr",
+	"B2vt2HtebR58/m8bOloa0ZrZ04jcZjtR1ZXNzMaFeYMZDmP0ujLQJyv9UDoYjKb4luDWO7V8BysHaAOm",
+	"SIgsU0uW4aAtSVoVPUnxBZimaiQwL5cYMeUChSaVFTHy9DPXhP+oCjOKYi1Q0jwDStggB71sS6SaED7N",
+	"O7X8KyVL4ZPgGVwy9aWHWPAyQ8KoMtKia/OuR1qhFVonlOZiW+5fpas1aTM/q67fJFBkao0usS3mzfqN",
+	"jH9iVvEkzkpjQU8yFfPs/Gx6Nh2g72G9S49nOGijyDWUegvr671QWT2B3cPaeXRhfOJTlFk2JA+H3Ryq",
+	"M+2Dhw5Tic+j321ncoMak6SwT5voUf6uGbf1wA0LrS6NfaVyLuQASsYBLKERwwrbZkn110Tp5U4Qi/ir",
+	"ln7TNbXDcyfwdTgc4F0AqI0C0DNkF22m9LWscrnoRiq8EjVlEA6iQU/XcxghhBcE9ht//kfzRozV+e27",
+	"9/3UKeZvYX1LW4cUg0xoXVSFA6rlp8Dezy5vXjNX1WYvL5qOC+JxcXT6DJ/E4+L4xQny1vDx0fTkRfXn",
+	"yfTsWdujbSb1S4f89vZdmLaXFwdGLCVCEiTz9vYdwpBUldr8kP44YVdCVtjj6CSdsCv+UP08o38ddX5+",
+	"NE3bmPjwbjo++/T70ej08Yf0x38e3Z2Mzz65v/CFe3tYvb077j4Kouh8MBVC8eyZAKnFAikFTWXlFZmG",
+	"1SLuYMzWgL73WolkkLXIS7VgMerJgmrpxhW1yId+Vvoe1d80+e3K3LK0YH7If2yyW5iK450UpMPuu0PP",
+	"wSlx8J95iIehAkSgUPE1LIZL9svtuxlb3sxe+rpL34RSZQZQAL6p3ekvBUjvmttLIk8RSkJsN9WbdyCX",
+	"NqXKTT+M7lXbftqOLpuMzp+dnh6fEgXu93Rn8ZvOXxEV8mMzbuP0axXAaFUX1VMqbuBJyyIhFbUKU4yc",
+	"J1SRHYa0jWvNnjQXArJkJ53/e9WOvof808oF32h94Enp//dc95vJdb9GUvt/KJH8RvLGPytHnLArzBnm",
+	"mG/xOKWS1EKjCrQvl6vE0LnswGFChbRAvjmudm088U7kCQnol2dRIdyhioF0ChGzWjCMEby+1pwDOgAU",
+	"LiToD/YKT+w/0KGQz9lnfO15eJJAMmIacrXCP5RmGoqMx5UvrWNLklDqg6PoDxoS0JpOxFdFNKoCZTDg",
+	"K23Ntq4GhApma7G1o+IUOMiNBi5/ZKxypDK4Vf2W/Xx7O6ON290DL168CNXg62lvdBHvWJiAVWDhs8Nd",
+	"C882AH3PLVx3mO2mC3TZ3+DYGq3KgKWCh9+kS9/xNvqulb2Ub2G94tkO4ja3ICmXSQamxhHG+QMfN6Wy",
+	"w3rcJu5supW4vRnnhf5VGTfdRtsNJEKjIWynTFfDnOY48ECE1i8abLSKcals6ptjZIDwOTcbv1JoZVWs",
+	"sk1JjJbqMnmrht7GxY4z3L4MWdTZ9GTHsq8Qyu5eGhFvjz0JSPQH+L6+/BALJqxv/mMFdylQwKsojYPt",
+	"BopXWULNyXoNB5G7xzrdcay9tbLm25cpZUgnz6bPtxH3Idklyg+vwqI8Cy2LcVHEA7ihARSqcUGvG6RX",
+	"lXapBl15/XbYlZ9tW/SVg0avl8OYx+/g79VQStQ5RLP8cy84p2SzrDTsUroxVRqYuYZUV0mHhHHDuKzX",
+	"if2Yrm852XaE4WjkKR+MRkfbFt7p7f36niMJGCskoY4qlHMNO02wq19bqdruSj1J34QrnW47yKAr9WcY",
+	"cqXPti07aNZ+2SGzDmKeIivNhWuUGCgs1fXfhtZfzC4rll/MLr0DJe8qMCVQpUXm7pHN+H6grlUHeVDL",
+	"9mfgmU2HejT6mkC+I6VJKNo5+CDQaEcepOXsdD9acJf3+xP0/g9Q9Gxnfc571Y4jCZt/wPzaijzkUTfh",
+	"JgoitQ6oHoTCYQwaAFhtqNJHGEPBuW1A7Si5sYJNmAsq27DUgxlR40rzD/V5B1L/djZEqdXOG9ZGgkbX",
+	"g1yagutgi8yvKZC7VJpMe898DWOBLqV0bcWssQPBnAm77TxhOXDZyAlDCxbcfXJi6cbSRWKbalUu09pk",
+	"GlGJimuqtGRGa5zH5ZrpMtsYWLXIPl0zHZtybG6zLiT4bhnha1xL+BpGX/q+OXRnB26nMfVxFBligL7B",
+	"jQZiAOgYpOVL58411W996N98G8JlUt80JJ7V/iJizuN7kISuF1UlLFpkii5G/S3EYfAGQpb5vHJwHU4/",
+	"PlZ1uh7hHwxs6fSvLkKIw6ExI1eyrh9pMKrU/tiIc0QsCk4VVYfkaRI1SdZfcLG1KnWzJLZZxX+fssOk",
+	"1tTEXzWb/3pxc315/eac3Q4fi6pqbA6WMw0ZcAPMWG5L41ppXZjWjfZ7VKzS0DHcbQA1qPq6vJIT5gkg",
+	"iEGMN77POmGujq+BmbK6pFEsTrlcAmJfPCQSBiuVrcBM2LViy5JrLi2QOqFafObatasW3Iq5yISl3Cfn",
+	"SdVkaoWlumD41NEoWoE2Tu6rQ54VKT90dTqQ1AIaHU+m1PBbcJuSkRzE3jCXEHB/N/RNhak/ZuhfRdWt",
+	"wL6GGQa9vhR4mUTn0RuwleGN2t8hHk2nT/tKKnD15K+Mqq5X/xnQ1o92Ot/ouM9q3EXjyclxsCfWNbAG",
+	"7p9ce2mr87Ld8Ri8lelcdNS3A40OhUajQNUXUF/bu3v1+hq8cbsdHaadbrh2r1roRsFX/DsF+0Z1PVBE",
+	"bzVHmXycKyms0kIuJ2YV1xVp3wHlA/WmfumKke3So6sjDlUNXRUvWLNzNbRQxcxVsPr1KlcQapV/XDGn",
+	"V7pxxZCB0ocrRrRKD66Q4MsGLv3fJPsucx/I011O3M6AXTobTF5dTtnPIF2K1krIXHrVSqZcauQTIZd8",
+	"hFINlwoMAn/E5V1gRRE+1M8WRf1esuqLhid/TnB+ODklB+c+YIgCHxwMNKE9eUchhd2yHb7u3bi08En9",
+	"CYrrn4iUhWxcfciqdMCEIu+Pjg+fP/YQy3QyPez2urWa1Pb+2rPxRUXga8/3JbncRZlla6ZRp2EFyX7X",
+	"My5m0IexJ9PDITp8RDhofT1Lk453T9p8Y/04ik5dQNk+I/SdMjG4zHOOksOAtfN00Sh6GC9Ox/BQgBbo",
+	"9tEgrS5R6wtu4zSAzurOjadwrxtNmw0mDqaDsRiNnhJK7xqtH+Hw1Ljvru7+/I3Z46gxO9AJcYd+nzoa",
+	"LV+iz/tUr8CTJHr81NRMJeGXBdGzNYVrnBl33+u7u/akTq/Ep4Cuv4KFkNBrssmrLzSfIjVCjfUa1TWl",
+	"weyPG8YZ5nUZMCKQOQo9wKJGLCISwVZgCKXBm+ys0rj/x7hqD/36AvjV6uf4jr6+o6/v6Os7+vqm0ZcL",
+	"J1+CvfYARY3/Euh/Cq61IJeDRqFzvdwbdQ29wY0I6xkCGp02Tf8fpNBNWDSKSo1++YAXwqAeNrRyU2X5",
+	"9PjfAQAA///Hx1VMYUkAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/apis/mesh/validate.go
+++ b/pkg/apis/mesh/validate.go
@@ -13,17 +13,11 @@ import (
 
 // CheckForInvalidConfig returns an error if config is not valid
 // Invalid configs:
-//   - AutoInjection is enabled but there are enabled namespaces
 //   - LoadBalancingMethod is "random" when CircuitBreakers exist
 //   - both tracing and telemetry are enabled
 //
 //nolint:goerr113 // can convert to constants at some point if desired
 func (config *MeshConfig) CheckForInvalidConfig(k8sClient client.Client) error {
-	if *config.IsAutoInjectEnabled && len(*config.EnabledNamespaces) > 0 {
-		return errors.New("invalid configuration: enabled namespaces should not be set " +
-			"when auto injection is enabled")
-	}
-
 	if k8sClient != nil && strings.Contains(string(config.LoadBalancingMethod), string(MeshConfigLoadBalancingMethodRandom)) {
 		cbs := &specs.CircuitBreakerList{}
 		ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -17,20 +17,19 @@ import (
 
 // Values is the top level representation of the Helm values.yaml.
 type Values struct {
-	Tracing              *Tracing   `yaml:"tracing" json:"tracing"`
-	Telemetry            *Telemetry `yaml:"telemetry" json:"telemetry"`
-	MTLS                 MTLS       `yaml:"mtls" json:"mtls"`
-	ClientMaxBodySize    string     `yaml:"clientMaxBodySize" json:"clientMaxBodySize"`
-	PrometheusAddress    string     `yaml:"prometheusAddress" json:"prometheusAddress"`
-	Environment          string     `yaml:"environment" json:"environment"`
-	AccessControlMode    string     `yaml:"accessControlMode" json:"accessControlMode"`
-	NGINXErrorLogLevel   string     `yaml:"nginxErrorLogLevel" json:"nginxErrorLogLevel"`
-	NGINXLBMethod        string     `yaml:"nginxLBMethod" json:"nginxLBMethod"`
-	NGINXLogFormat       string     `yaml:"nginxLogFormat" json:"nginxLogFormat"`
-	Registry             Registry   `yaml:"registry" json:"registry"`
-	EnabledNamespaces    []string   `yaml:"enabledNamespaces" json:"enabledNamespaces"`
-	EnableUDP            bool       `yaml:"enableUDP" json:"enableUDP"`
-	DisableAutoInjection bool       `yaml:"disableAutoInjection" json:"disableAutoInjection"`
+	Tracing            *Tracing   `yaml:"tracing" json:"tracing"`
+	Telemetry          *Telemetry `yaml:"telemetry" json:"telemetry"`
+	MTLS               MTLS       `yaml:"mtls" json:"mtls"`
+	ClientMaxBodySize  string     `yaml:"clientMaxBodySize" json:"clientMaxBodySize"`
+	PrometheusAddress  string     `yaml:"prometheusAddress" json:"prometheusAddress"`
+	Environment        string     `yaml:"environment" json:"environment"`
+	AccessControlMode  string     `yaml:"accessControlMode" json:"accessControlMode"`
+	NGINXErrorLogLevel string     `yaml:"nginxErrorLogLevel" json:"nginxErrorLogLevel"`
+	NGINXLBMethod      string     `yaml:"nginxLBMethod" json:"nginxLBMethod"`
+	NGINXLogFormat     string     `yaml:"nginxLogFormat" json:"nginxLogFormat"`
+	Registry           Registry   `yaml:"registry" json:"registry"`
+	EnabledNamespaces  []string   `yaml:"enabledNamespaces" json:"enabledNamespaces"`
+	EnableUDP          bool       `yaml:"enableUDP" json:"enableUDP"`
 }
 
 // Registry is the registry struct within Values.


### PR DESCRIPTION
### Proposed changes
This PR removes the ability to globally enable auto-injection. A user will now need to enable auto-injection per namespace or pod.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
    - Doc changes will be in another PR. 
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
