### PR TITLE
Include a warning when building cli with an empty version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ linker_flags = -s -w -extldflags "-fno-PIC -static" -X main.version=$(VERSION) -
 build: build-cli ## Build all Go binaries
 
 build-cli: output-dir ## Build the nginx-meshctl binary
+	@## check if version is set
+	@if [ -z "$(VERSION)" ]; then \
+	  echo '$@:WARNING: building the CLI with an empty version will break upgrade capability'; \
+	fi
 	CGO_ENABLED=0 go build -ldflags '$(linker_flags) -X main.pkgName=nginx-meshctl' -o $(OUTPUT_DIR)/$(GOOS)-$(GOARCH)/nginx-meshctl$(EXTENSION) cmd/nginx-meshctl/main.go
 
 .PHONY: test


### PR DESCRIPTION
### Proposed changes
When building the meshctl binary if a build is specified to have no version (eg `make VERSION= build`) no errors will be thrown at compile time, but any calls to the upgrade command will throw an unhelpful error. 

With this PR there will be a warning at build time that the upgrade command will not work. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
