### PR TITLE
Alter webhook configuration to use label selectors

### DIFF
--- a/helm-chart/templates/nginx-mesh-api.yaml
+++ b/helm-chart/templates/nginx-mesh-api.yaml
@@ -183,11 +183,11 @@ metadata:
 webhooks:
 - name: nginx-mesh-api.sidecar.injector
   namespaceSelector:
-    matchLabels:
+    matchLables:
       injector.nsm.nginx.com/auto-inject: enabled
   objectSelector:
-    matchLabels:
-      injector.nsm.nginx.com/auto-inject: enabled
+      matchLables:
+       injector.nsm.nginx.com/auto-inject: enabled
   clientConfig:
     service:
       name: nginx-mesh-webhook

--- a/helm-chart/templates/nginx-mesh-api.yaml
+++ b/helm-chart/templates/nginx-mesh-api.yaml
@@ -181,6 +181,7 @@ metadata:
     app.kubernetes.io/part-of: nginx-service-mesh
     spiffe.io/webhook: "true"
 webhooks:
+  {{- /* Case 1: Namespace is labeled for injection and not in denylist, Pod does not disable injection */}}
 - name: nginx-mesh-api-ns.sidecar.injector
   namespaceSelector:
     matchExpressions:
@@ -191,6 +192,12 @@ webhooks:
       - {{ .Release.Namespace }}
     matchLabels:
       injector.nsm.nginx.com/auto-inject: enabled
+  objectSelector:
+    matchExpressions:
+    - key: injector.nsm.nginx.com/auto-inject
+      operator: NotIn
+      values:
+      - disabled
   clientConfig:
     service:
       name: nginx-mesh-webhook
@@ -203,6 +210,8 @@ webhooks:
     apiVersions: ["v1"]
     operations: ["CREATE"]
     resources: ["pods"]
+
+  {{- /* Case 2: Pod is labeled for injection, namespace is not in denylist */}} 
 - name: nginx-mesh-api-obj.sidecar.injector
   namespaceSelector:
     matchExpressions:
@@ -226,14 +235,9 @@ webhooks:
     apiVersions: ["v1"]
     operations: ["CREATE"]
     resources: ["pods"]
+    
+  {{- /* Case 3: Pod is labeled for ingress */}} 
 - name: nginx-mesh-api-ingress.sidecar.injector
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: NotIn
-      values:
-      - kube-system
-      - {{ .Release.Namespace }}
   objectSelector:
     matchLabels:
       nsm.nginx.com/enable-ingress: "true"
@@ -249,14 +253,9 @@ webhooks:
     apiVersions: ["v1"]
     operations: ["CREATE"]
     resources: ["pods"]
+
+  {{- /* Case 4: Pod is labeled for egress */}}     
 - name: nginx-mesh-api-egress.sidecar.injector
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: NotIn
-      values:
-      - kube-system
-      - {{ .Release.Namespace }}
   objectSelector:
     matchLabels:
       nsm.nginx.com/enable-egress: "true"

--- a/helm-chart/templates/nginx-mesh-api.yaml
+++ b/helm-chart/templates/nginx-mesh-api.yaml
@@ -176,17 +176,39 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: sidecar-injector-webhook-cfg.internal.builtin.nsm.nginx
+  name: sidecar-injector-webhook-ns.internal.builtin.nsm.nginx
   labels:
     app.kubernetes.io/part-of: nginx-service-mesh
     spiffe.io/webhook: "true"
 webhooks:
 - name: nginx-mesh-api.sidecar.injector
   namespaceSelector:
-    matchLables:
+    matchLabels:
       injector.nsm.nginx.com/auto-inject: enabled
+  clientConfig:
+    service:
+      name: nginx-mesh-webhook
+      namespace: {{ .Release.Namespace }}
+      path: /inject
+  sideEffects: None
+  admissionReviewVersions: ["v1"]
+  rules:
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    operations: ["CREATE"]
+    resources: ["pods"]
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: sidecar-injector-webhook-cfg-obj.internal.builtin.nsm.nginx
+  labels:
+    app.kubernetes.io/part-of: nginx-service-mesh
+    spiffe.io/webhook: "true"
+webhooks:
+- name: nginx-mesh-api.sidecar.injector
   objectSelector:
-      matchLables:
+      matchLabels:
        injector.nsm.nginx.com/auto-inject: enabled
   clientConfig:
     service:

--- a/helm-chart/templates/nginx-mesh-api.yaml
+++ b/helm-chart/templates/nginx-mesh-api.yaml
@@ -176,13 +176,19 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: sidecar-injector-webhook-ns.internal.builtin.nsm.nginx
+  name: sidecar-injector-webhook-cfg.internal.builtin.nsm.nginx
   labels:
     app.kubernetes.io/part-of: nginx-service-mesh
     spiffe.io/webhook: "true"
 webhooks:
-- name: nginx-mesh-api.sidecar.injector
+- name: nginx-mesh-api-ns.sidecar.injector
   namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - {{ .Release.Namespace }}
     matchLabels:
       injector.nsm.nginx.com/auto-inject: enabled
   clientConfig:
@@ -197,16 +203,14 @@ webhooks:
     apiVersions: ["v1"]
     operations: ["CREATE"]
     resources: ["pods"]
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: sidecar-injector-webhook-cfg-obj.internal.builtin.nsm.nginx
-  labels:
-    app.kubernetes.io/part-of: nginx-service-mesh
-    spiffe.io/webhook: "true"
-webhooks:
-- name: nginx-mesh-api.sidecar.injector
+- name: nginx-mesh-api-obj.sidecar.injector
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - {{ .Release.Namespace }}
   objectSelector:
       matchLabels:
        injector.nsm.nginx.com/auto-inject: enabled

--- a/helm-chart/templates/nginx-mesh-api.yaml
+++ b/helm-chart/templates/nginx-mesh-api.yaml
@@ -183,12 +183,16 @@ metadata:
 webhooks:
 - name: nginx-mesh-api.sidecar.injector
   namespaceSelector:
-      namespaceSelector:
-        matchLabels:
-          injector.nsm.nginx.com/auto-inject: enabled
-      objectSelector:
-        matchLabels:
-          injector.nsm.nginx.com/auto-inject: enabled
+    matchLabels:
+      injector.nsm.nginx.com/auto-inject: enabled
+  objectSelector:
+    matchLabels:
+      injector.nsm.nginx.com/auto-inject: enabled
+  clientConfig:
+    service:
+      name: nginx-mesh-webhook
+      namespace: {{ .Release.Namespace }}
+      path: /inject
   sideEffects: None
   admissionReviewVersions: ["v1"]
   rules:

--- a/helm-chart/templates/nginx-mesh-api.yaml
+++ b/helm-chart/templates/nginx-mesh-api.yaml
@@ -226,6 +226,52 @@ webhooks:
     apiVersions: ["v1"]
     operations: ["CREATE"]
     resources: ["pods"]
+- name: nginx-mesh-api-ingress.sidecar.injector
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - {{ .Release.Namespace }}
+  objectSelector:
+    matchLabels:
+      nsm.nginx.com/enable-ingress: "true"
+  clientConfig:
+    service:
+      name: nginx-mesh-webhook
+      namespace: {{ .Release.Namespace }}
+      path: /inject
+  sideEffects: None
+  admissionReviewVersions: ["v1"]
+  rules:
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    operations: ["CREATE"]
+    resources: ["pods"]
+- name: nginx-mesh-api-egress.sidecar.injector
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - {{ .Release.Namespace }}
+  objectSelector:
+    matchLabels:
+      nsm.nginx.com/enable-egress: "true"
+  clientConfig:
+    service:
+      name: nginx-mesh-webhook
+      namespace: {{ .Release.Namespace }}
+      path: /inject
+  sideEffects: None
+  admissionReviewVersions: ["v1"]
+  rules:
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    operations: ["CREATE"]
+    resources: ["pods"]
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/helm-chart/templates/nginx-mesh-api.yaml
+++ b/helm-chart/templates/nginx-mesh-api.yaml
@@ -246,7 +246,7 @@ webhooks:
     resources: ["pods"]
     
   {{- /* Case 3: Pod is labeled for ingress */}} 
-- name: nginx-mesh-api-ingress.sidecar.injector
+- name: nginx-mesh-api.ingress.injector
   objectSelector:
     matchLabels:
       nsm.nginx.com/enable-ingress: "true"

--- a/helm-chart/templates/nginx-mesh-api.yaml
+++ b/helm-chart/templates/nginx-mesh-api.yaml
@@ -264,7 +264,7 @@ webhooks:
     resources: ["pods"]
 
   {{- /* Case 4: Pod is labeled for egress */}}     
-- name: nginx-mesh-api-egress.sidecar.injector
+- name: nginx-mesh-api.egress.injector
   objectSelector:
     matchLabels:
       nsm.nginx.com/enable-egress: "true"

--- a/helm-chart/templates/nginx-mesh-api.yaml
+++ b/helm-chart/templates/nginx-mesh-api.yaml
@@ -181,7 +181,7 @@ metadata:
     app.kubernetes.io/part-of: nginx-service-mesh
     spiffe.io/webhook: "true"
 webhooks:
-  {{- /* Case 1: Namespace is labeled for injection and not in denylist, Pod does not disable injection */}}
+  {{- /* Case 1: Namespace is labeled for injection and not in denylist, Pod is not already injected and does not disable injection */}}
 - name: nginx-mesh-api-ns.sidecar.injector
   namespaceSelector:
     matchExpressions:
@@ -198,6 +198,10 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: injector.nsm.nginx.com/status
+      operator: NotIn
+      values:
+      - injected
   clientConfig:
     service:
       name: nginx-mesh-webhook
@@ -211,7 +215,7 @@ webhooks:
     operations: ["CREATE"]
     resources: ["pods"]
 
-  {{- /* Case 2: Pod is labeled for injection, namespace is not in denylist */}} 
+  {{- /* Case 2: Pod is labeled for injection, not already injected, and namespace is not in denylist */}} 
 - name: nginx-mesh-api-obj.sidecar.injector
   namespaceSelector:
     matchExpressions:
@@ -221,8 +225,13 @@ webhooks:
       - kube-system
       - {{ .Release.Namespace }}
   objectSelector:
-      matchLabels:
-       injector.nsm.nginx.com/auto-inject: enabled
+    matchLabels:
+      injector.nsm.nginx.com/auto-inject: enabled
+    matchExpressions:
+    - key: injector.nsm.nginx.com/status
+      operator: NotIn
+      values:
+      - injected
   clientConfig:
     service:
       name: nginx-mesh-webhook

--- a/helm-chart/templates/nginx-mesh-api.yaml
+++ b/helm-chart/templates/nginx-mesh-api.yaml
@@ -183,17 +183,12 @@ metadata:
 webhooks:
 - name: nginx-mesh-api.sidecar.injector
   namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: NotIn
-      values:
-      - kube-system
-      - {{ .Release.Namespace }}
-  clientConfig:
-    service:
-      name: nginx-mesh-webhook
-      namespace: {{ .Release.Namespace }}
-      path: /inject
+      namespaceSelector:
+        matchLabels:
+          injector.nsm.nginx.com/auto-inject: enabled
+      objectSelector:
+        matchLabels:
+          injector.nsm.nginx.com/auto-inject: enabled
   sideEffects: None
   admissionReviewVersions: ["v1"]
   rules:


### PR DESCRIPTION
#### JIRA
- [NSM-384: No Pods can be created if mesh-api isn't running](https://nginxsoftware.atlassian.net/browse/NSM-384)

### Proposed changes
Helm chart changed to add separate MutatingWebhookConfigurations for namespace selectors and object selectors. Both selectors select on our injection annotation.

All e2e tests pass, including Ingress Controller integration tests.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
