### PR TITLE
Fix typo in traffic split tutorial

### DIFF
--- a/docs/content/tutorials/trafficsplit-deployments.md
+++ b/docs/content/tutorials/trafficsplit-deployments.md
@@ -221,7 +221,7 @@ For this version of the target app, let's try using a canary deployment strategy
    **Command:**
 
    ```bash
-   kubectl delete -f target-v2.1-successful.yaml
+   kubectl delete -f target-v2.0-failing.yaml
    ```
 
 ### Deploy a New Version of the Target App using a Blue-Green Deployment


### PR DESCRIPTION
### Proposed changes
Fixed typo in the TrafficSplit tutorial where it was deleting the incorrect deployment.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
