### PR TITLE
Fix dry run for deploy command

### DIFF
--- a/internal/nginx-meshctl/deploy/deploy.go
+++ b/internal/nginx-meshctl/deploy/deploy.go
@@ -55,7 +55,9 @@ func (d *Deployer) Deploy() (string, error) {
 
 		return "", fmt.Errorf("%v: %w", meshErrors.ErrCheckingExistence, existsErr) //nolint:errorlint // only one %w allowed
 	}
-	fmt.Println("Deploying NGINX Service Mesh...")
+	if !d.DryRun {
+		fmt.Println("Deploying NGINX Service Mesh...")
+	}
 
 	actionConfig, err := d.k8sClient.HelmAction(d.k8sClient.Namespace())
 	if err != nil {
@@ -67,6 +69,13 @@ func (d *Deployer) Deploy() (string, error) {
 	installer.CreateNamespace = true
 	installer.ReleaseName = "nginx-service-mesh"
 	installer.DryRun = d.DryRun
+
+	if d.DryRun {
+		installer.ClientOnly = true
+		installer.Replace = true
+		installer.IncludeCRDs = true
+		chart.Metadata.KubeVersion = ""
+	}
 
 	rel, err := installer.Run(chart, valuesMap)
 	if err != nil {


### PR DESCRIPTION
With the recent updates to CRDs, our dry-run command no longer rendered manifests properly. Using the `helm template` command as a reference, some additional fields were needed to render the manifest.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
