### PR TITLE
Update telemetry config to regular value

### DIFF
--- a/pkg/apis/mesh/config.go
+++ b/pkg/apis/mesh/config.go
@@ -33,7 +33,7 @@ type FullMeshConfig struct { //nolint:govet // fieldalignment not desired
 	Registry Registry `yaml:"registry" json:"registry"`
 
 	// Telemetry is the configuration for telemetry.
-	Telemetry *Telemetry `yaml:"telemetry,omitempty" json:"telemetry,omitempty"`
+	Telemetry Telemetry `yaml:"telemetry" json:"telemetry"`
 
 	// EnableUDP traffic proxying (beta).
 	EnableUDP bool `yaml:"enableUDP" json:"enableUDP"`
@@ -111,23 +111,13 @@ type Registry struct { //nolint:govet // fieldalignment not desired
 // DeepCopyInto performs a deepcopy of the FullMeshConfig.
 func (in *FullMeshConfig) DeepCopyInto(out *FullMeshConfig) {
 	*out = *in
-	if in.Telemetry != nil {
-		in, out := &in.Telemetry, &out.Telemetry
-		*out = new(Telemetry)
-		(*in).DeepCopyInto(*out)
-	}
-}
-
-// DeepCopyInto performs a deepcopy of the Telemetry config.
-func (in *Telemetry) DeepCopyInto(out *Telemetry) {
-	*out = *in
-	if in.Exporters != nil {
-		in, out := &in.Exporters, &out.Exporters
+	if in.Telemetry.Exporters != nil {
+		in, out := &in.Telemetry.Exporters, &out.Telemetry.Exporters
 		*out = new(Exporters)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.SamplerRatio != nil {
-		in, out := &in.SamplerRatio, &out.SamplerRatio
+	if in.Telemetry.SamplerRatio != nil {
+		in, out := &in.Telemetry.SamplerRatio, &out.Telemetry.SamplerRatio
 		*out = new(float32)
 		**out = **in
 	}


### PR DESCRIPTION
The telemetry config was originally a pointer in the internal mesh config, however it's easier for us to process and display to a user if it's just a regular value. Now if the value is not specified, it'll still show up in the config as `telemetry: {}` for informational purposes.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
