### PR TITLE
Add control-plane and sidecar shared resources for retry timeouts

### DIFF
--- a/helm-chart/templates/nginx-mesh-controller.yaml
+++ b/helm-chart/templates/nginx-mesh-controller.yaml
@@ -59,6 +59,9 @@ rules:
 - apiGroups: ["nsm.nginx.com"]
   resources: ["meshconfigclasses", "meshconfigs"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["nsm.nginx.com"]
+  resources: ["retrytimeoutconfigs"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/sidecar/config.go
+++ b/pkg/sidecar/config.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/nginxinc/nginx-service-mesh/pkg/apis/mesh"
+	"github.com/nginxinc/nginx-service-mesh/pkg/apis/mesh/v1alpha1"
 	specs "github.com/nginxinc/nginx-service-mesh/pkg/apis/specs/v1alpha1"
 )
 
@@ -27,6 +28,7 @@ type Config struct {
 	TrafficSplits       map[string]AgentTrafficSplit
 	RateLimits          AgentLimit
 	CircuitBreakers     AgentBreaker
+	RetryTimeouts       AgentKeyval
 	HTTPAccessControl   map[string]AgentKeyval
 	StreamAccessControl map[string]AgentKeyval
 	MeshConfig          mesh.FullMeshConfig
@@ -214,6 +216,9 @@ func NewAgentLimit() AgentLimit {
 
 // AgentBreaker is a map of destination names to their associated circuit breaker specs.
 type AgentBreaker map[string]specs.CircuitBreakerSpec
+
+// AgentRetryTimeout is a map of destination names to their associated retry/timeout specs.
+type AgentRetryTimeout map[string]v1alpha1.RetryTimeoutConfigSpec
 
 // Egress ports.
 const (

--- a/pkg/sidecar/config.go
+++ b/pkg/sidecar/config.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/nginxinc/nginx-service-mesh/pkg/apis/mesh"
-	"github.com/nginxinc/nginx-service-mesh/pkg/apis/mesh/v1alpha1"
 	specs "github.com/nginxinc/nginx-service-mesh/pkg/apis/specs/v1alpha1"
 )
 
@@ -216,9 +215,6 @@ func NewAgentLimit() AgentLimit {
 
 // AgentBreaker is a map of destination names to their associated circuit breaker specs.
 type AgentBreaker map[string]specs.CircuitBreakerSpec
-
-// AgentRetryTimeout is a map of destination names to their associated retry/timeout specs.
-type AgentRetryTimeout map[string]v1alpha1.RetryTimeoutConfigSpec
 
 // Egress ports.
 const (


### PR DESCRIPTION
### Proposed changes
Add all resources needed for the control-plane and sidecar to handle retry-timeout CRDs

- Update config struct to pass retryTimeout KVs
- Update helm to allow listing the retrytimeoutconfigs type

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
