### PR TITLE
Add SCC and doc for sidecar openshift permissions

### DIFF
--- a/docs/content/get-started/openshift-platform/considerations.md
+++ b/docs/content/get-started/openshift-platform/considerations.md
@@ -24,6 +24,12 @@ The NGINX Service Mesh deployment experience is the exact same as in other envir
 nginx-meshctl deploy ... --environment openshift"
 ```
 
+When injecting sidecars into your worklods, OpenShift's default security policies do not allow the necessary permissions. To enable the proper permissions for sidecar injection, you can attach your workloads to the `nginx-mesh-sidecar-permissions` SecurityContextConstraint (SCC) by running:
+
+```bash
+oc adm policy add-scc-to-group nginx-mesh-sidecar-permissions system:serviceaccounts:<workload-namespace>
+```
+
 ### Remove
 
 When removing NGINX Service Mesh, the CSI Driver should be running until all injected Pods are either re-rolled to remove the sidecar proxy, or terminated. This is because the CSI Driver must unmount and service any injected Pods when they are terminated.

--- a/docs/content/get-started/openshift-platform/considerations.md
+++ b/docs/content/get-started/openshift-platform/considerations.md
@@ -24,7 +24,7 @@ The NGINX Service Mesh deployment experience is the exact same as in other envir
 nginx-meshctl deploy ... --environment openshift"
 ```
 
-When injecting sidecars into your worklods, OpenShift's default security policies do not allow the necessary permissions. To enable the proper permissions for sidecar injection, you can attach your workloads to the `nginx-mesh-sidecar-permissions` SecurityContextConstraint (SCC) by running:
+When injecting sidecars into your workloads, OpenShift's default security policies do not allow the necessary permissions. To enable the proper permissions for sidecar injection, you can attach your workloads to the `nginx-mesh-sidecar-permissions` SecurityContextConstraint (SCC) by running:
 
 ```bash
 oc adm policy add-scc-to-group nginx-mesh-sidecar-permissions system:serviceaccounts:<workload-namespace>

--- a/helm-chart/templates/post-delete-hook.yaml
+++ b/helm-chart/templates/post-delete-hook.yaml
@@ -264,6 +264,7 @@ data:
               kubectl delete clusterrole system:openshift:scc:nginx-mesh-spiffe-csi-driver-permissions --ignore-not-found
               kubectl delete rolebinding system:openshift:scc:nginx-mesh-spiffe-csi-driver-permissions --ignore-not-found
               kubectl delete scc nginx-mesh-spiffe-csi-driver-permissions --ignore-not-found
+              kubectl delete scc nginx-mesh-sidecar-permissions --ignore-not-found
               kubectl delete secret {{ include "registry-key-name" . }} --ignore-not-found
               kubectl delete serviceaccount csi-driver-sentinel --ignore-not-found
               kubectl delete clusterrolebinding csi-driver-sentinel.builtin.nsm.nginx --ignore-not-found
@@ -317,6 +318,7 @@ spec:
             kubectl delete clusterrole system:openshift:scc:nginx-mesh-spiffe-csi-driver-permissions --ignore-not-found
             kubectl delete rolebinding system:openshift:scc:nginx-mesh-spiffe-csi-driver-permissions --ignore-not-found
             kubectl delete scc nginx-mesh-spiffe-csi-driver-permissions --ignore-not-found
+            kubectl delete scc nginx-mesh-sidecar-permissions --ignore-not-found
           else
             {{- if (include "docker-config-json" .) }}
             kubectl get secret {{ include "registry-key-name" . }}

--- a/helm-chart/templates/sidecar-scc.yaml
+++ b/helm-chart/templates/sidecar-scc.yaml
@@ -1,0 +1,35 @@
+{{- if eq .Values.environment "openshift" }}
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: nginx-mesh-sidecar-permissions
+  labels:
+    app.kubernetes.io/part-of: nginx-service-mesh
+  annotations:
+    "helm.sh/resource-policy": keep
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostPID: false
+allowHostNetwork: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- NET_ADMIN
+- NET_RAW
+- SYS_ADMIN
+- SYS_RESOURCE
+seccompProfiles:
+- "*"
+seLinuxContext:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+requiredDropCapabilities:
+- ALL
+volumes:
+- csi
+- projected
+{{- end }}


### PR DESCRIPTION
Sidecars require a specific SCC in order to function in OpenShift, so we've added that SCC to our helm chart and a note to our docs telling users how to attach to it.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
