### PR TITLE
Add registry server flag on upgrade

### DIFF
--- a/docs/content/guides/upgrade.md
+++ b/docs/content/guides/upgrade.md
@@ -42,6 +42,10 @@ nginx-meshctl upgrade
 
 This will upgrade the NGINX Service Mesh control plane to the latest version. All user configuration (traffic policies, mesh configuration, deploy configuration) is preserved through the upgrade. New applications will not be injected during the upgrade and existing applications will not receive configuration updates. Existing applications may not function properly until updated. It is recommended that upgrades are only performed during a maintenance window due to the brief downtime.
 
+By default, the mesh will pull images from the registry the mesh was originally deployed with. If you would like to pull from a different registry, you can specify it with the `--registry-server` flag on the CLI.
+
+Additionally, if you would like to upgrade to a custom image tag you can use the `--image-tag` flag with the CLI.
+
 Once the upgrade is complete, if your applications support rolling updates, re-roll using the following command:
 
 ```bash

--- a/docs/content/guides/upgrade.md
+++ b/docs/content/guides/upgrade.md
@@ -42,9 +42,9 @@ nginx-meshctl upgrade
 
 This will upgrade the NGINX Service Mesh control plane to the latest version. All user configuration (traffic policies, mesh configuration, deploy configuration) is preserved through the upgrade. New applications will not be injected during the upgrade and existing applications will not receive configuration updates. Existing applications may not function properly until updated. It is recommended that upgrades are only performed during a maintenance window due to the brief downtime.
 
-By default, the mesh will pull images from the registry the mesh was originally deployed with. If you would like to pull from a different registry, you can specify it with the `--registry-server` flag on the CLI.
+By default, the mesh will pull images from the registry that it was originally deployed with. If you would like to pull from a different registry, you can use the`--registry-server` flag.
 
-Additionally, if you would like to upgrade to a custom image tag you can use the `--image-tag` flag with the CLI.
+Additionally, if you would like to upgrade to a custom image tag you can use the `--image-tag` flag.
 
 Once the upgrade is complete, if your applications support rolling updates, re-roll using the following command:
 

--- a/internal/nginx-meshctl/commands/upgrade.go
+++ b/internal/nginx-meshctl/commands/upgrade.go
@@ -254,7 +254,7 @@ func (u *upgrader) upgrade(version string, registry string) error {
 // - copy on top of the new release's deploy-time configuration
 // - set new version
 // - set new registry server if needed.
-func (u *upgrader) buildValues(ctx context.Context, version string, registry string) (map[string]interface{}, error) {
+func (u *upgrader) buildValues(ctx context.Context, version, registry string) (map[string]interface{}, error) {
 	// get the previous deployment configuration
 	_, oldValueBytes, err := helm.GetDeployValues(u.k8sClient, "nginx-service-mesh")
 	if err != nil {

--- a/internal/nginx-meshctl/commands/upgrade.go
+++ b/internal/nginx-meshctl/commands/upgrade.go
@@ -59,12 +59,12 @@ func Upgrade(version string) *cobra.Command {
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		namespace := initK8sClient.Namespace()
 		// Verify mesh install exists
-		if _, err := verifyMeshInstall(initK8sClient); err != nil {
+		if _, err = verifyMeshInstall(initK8sClient); err != nil {
 			return err
 		}
 		if !yes {
 			msg := fmt.Sprintf("Preparing to upgrade NGINX Service Mesh in namespace \"%s\".\n%s\n", namespace, NSMv2UpgradeWarning)
-			if err := ReadYes(msg); err != nil {
+			if err = ReadYes(msg); err != nil {
 				return err
 			}
 		}
@@ -74,7 +74,7 @@ func Upgrade(version string) *cobra.Command {
 			version = tagOverride
 		}
 
-		upgrader, err := newUpgrader(files, values, initK8sClient, dryRun)
+		upgrader := newUpgrader(files, values, initK8sClient, dryRun)
 		if err != nil {
 			return fmt.Errorf("error initializing upgrader: %w", err)
 		}
@@ -201,13 +201,13 @@ func newUpgrader(
 	values *helm.Values,
 	k8sClient k8s.Client,
 	dryRun bool,
-) (*upgrader, error) {
+) *upgrader {
 	return &upgrader{
 		files:     files,
 		values:    values,
 		k8sClient: k8sClient,
 		dryRun:    dryRun,
-	}, nil
+	}
 }
 
 // upgrade the mesh by calling "helm upgrade".
@@ -260,8 +260,8 @@ func (u *upgrader) upgrade(version string, registry string) error {
 // - copy on top of the new release's deploy-time configuration
 // - get previous release's run-time configuration (mesh-config ConfigMap)
 // - copy on top of the new release's deploy-time configuration
-// - set new version.
-// - set new registry server if needed
+// - set new version
+// - set new registry server if needed.
 func (u *upgrader) buildValues(ctx context.Context, version string, registry string) (map[string]interface{}, error) {
 	// get the previous deployment configuration
 	_, oldValueBytes, err := helm.GetDeployValues(u.k8sClient, "nginx-service-mesh")

--- a/internal/nginx-meshctl/commands/upgrade_test.go
+++ b/internal/nginx-meshctl/commands/upgrade_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"github.com/nginxinc/nginx-service-mesh/pkg/helm"
 	"os"
 	"time"
 
@@ -66,7 +67,9 @@ var _ = Describe("Upgrade", func() {
 	BeforeEach(func() {
 		var err error
 		fakeK8s = fake.NewFakeK8s(v1.NamespaceDefault, shouldSkipRelease)
-		upg, err = newUpgrader(fakeK8s, true)
+		files, values, err := helm.GetBufferedFilesAndValues()
+		Expect(err).ToNot(HaveOccurred())
+		upg, err = newUpgrader(files, values, fakeK8s, true)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -74,7 +77,7 @@ var _ = Describe("Upgrade", func() {
 		It("upgrades the mesh using telemetry config", func() {
 			createMeshConfigMap(fakeK8s.ClientSet(), fakeK8s.Namespace())
 
-			Expect(upg.upgrade("x.x.x")).To(Succeed())
+			Expect(upg.upgrade("x.x.x", "")).To(Succeed())
 			// check some values
 			Expect(upg.values.Registry.ImageTag).To(Equal("x.x.x"))
 			Expect(upg.values.AccessControlMode).To(Equal("deny"))

--- a/internal/nginx-meshctl/commands/upgrade_test.go
+++ b/internal/nginx-meshctl/commands/upgrade_test.go
@@ -3,9 +3,10 @@ package commands
 import (
 	"context"
 	"encoding/json"
-	"github.com/nginxinc/nginx-service-mesh/pkg/helm"
 	"os"
 	"time"
+
+	"github.com/nginxinc/nginx-service-mesh/pkg/helm"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -69,8 +70,7 @@ var _ = Describe("Upgrade", func() {
 		fakeK8s = fake.NewFakeK8s(v1.NamespaceDefault, shouldSkipRelease)
 		files, values, err := helm.GetBufferedFilesAndValues()
 		Expect(err).ToNot(HaveOccurred())
-		upg, err = newUpgrader(files, values, fakeK8s, true)
-		Expect(err).ToNot(HaveOccurred())
+		upg = newUpgrader(files, values, fakeK8s, true)
 	})
 
 	Context("upgrades the mesh", func() {


### PR DESCRIPTION
### Proposed changes
Currently the upgrade to version (image tag) is baked into the CLI, and the registry server value defaults to whatever the mesh was last deployed with. This change will allow users to override those values with flags in the `upgrade` command.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
