### PR TITLE
Generate CLI Documentation from Go code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ generate: ## Generate Go code for apis and fakes
 	go generate ./...
 	go run sigs.k8s.io/controller-tools/cmd/controller-gen object paths=./pkg/apis/...
 	scripts/generateSchema.sh api/upstream-ca-validation.json > internal/nginx-meshctl/upstreamauthority/schema.go
+	go run -ldflags '-X main.genDocs=true' cmd/nginx-meshctl/main.go > /dev/null
 	$(MAKE) format
 
 .PHONY: output-dir

--- a/cmd/nginx-meshctl/main.go
+++ b/cmd/nginx-meshctl/main.go
@@ -68,9 +68,9 @@ func generateCompletion(cmd *cobra.Command, docsPath string) error {
 		if strings.Contains(line, "Usage:") {
 			_, err = mdFile.WriteString("\n```\n")
 		} else if strings.Contains(line, "Available Commands:") {
-			_, err = mdFile.WriteString("```\n### Available Commands\n\n```\n")
+			_, err = mdFile.WriteString("```\n\n### Available Commands\n\n```\n")
 		} else if strings.Contains(line, "Global Flags:") {
-			_, err = mdFile.WriteString("```\n### Options\n\n```\n")
+			_, err = mdFile.WriteString("```\n\n### Options\n\n```\n")
 		} else if strings.Contains(line, "for more information about") {
 			_, err = mdFile.WriteString("```\n")
 		} else if len(line) > 0 {

--- a/cmd/nginx-meshctl/main.go
+++ b/cmd/nginx-meshctl/main.go
@@ -151,16 +151,19 @@ func generateMarkdown(cmd *cobra.Command) error {
 		return err
 	}
 
+	alt := 1
 	re := regexp.MustCompile("## nginx-meshctl ([a-z]+)")
 	caser := cases.Title(language.English)
 	scanner := bufio.NewScanner(strings.NewReader(buf.String()))
 	for scanner.Scan() {
 		line := strings.ReplaceAll(scanner.Text(), "ke.agarwal", "<user>")
 		if list := re.FindStringSubmatch(line); list != nil {
-			if _, err := finalFile.WriteString("## " + caser.String(list[len(list)-1]) + "\n"); err != nil {
-				return err
+			line = "## " + caser.String(list[len(list)-1]) + "\n"
+		} else if strings.Contains(line, "```") {
+			if alt > 0 {
+				line = strings.ReplaceAll(line, "```", "```txt")
 			}
-			continue
+			alt *= -1
 		}
 		// don't add cobra-generated footer
 		if !strings.Contains(line, "SEE ALSO") && !strings.Contains(line, "* [nginx-meshctl") {

--- a/cmd/nginx-meshctl/main.go
+++ b/cmd/nginx-meshctl/main.go
@@ -66,11 +66,11 @@ func generateCompletion(cmd *cobra.Command, docsPath string) error {
 	for scanner.Scan() {
 		line := strings.ReplaceAll(scanner.Text(), "ke.agarwal", "<user>")
 		if strings.Contains(line, "Usage:") {
-			_, err = mdFile.WriteString("```\n")
+			_, err = mdFile.WriteString("\n```\n")
 		} else if strings.Contains(line, "Available Commands:") {
-			_, err = mdFile.WriteString("```\n### " + line + "\n```\n")
+			_, err = mdFile.WriteString("```\n### Available Commands\n\n```\n")
 		} else if strings.Contains(line, "Global Flags:") {
-			_, err = mdFile.WriteString("```\n### Options\n```\n")
+			_, err = mdFile.WriteString("```\n### Options\n\n```\n")
 		} else if strings.Contains(line, "for more information about") {
 			_, err = mdFile.WriteString("```\n")
 		} else if len(line) > 0 {

--- a/cmd/nginx-meshctl/main.go
+++ b/cmd/nginx-meshctl/main.go
@@ -2,22 +2,173 @@
 package main
 
 import (
+	"bufio"
+	"io"
+	"log"
 	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
 
 	"github.com/nginxinc/nginx-service-mesh/internal/nginx-meshctl/commands"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var (
 	pkgName = "nginx-meshctl"
 	version = "0.0.0"
 	commit  = "local"
+	genDocs = ""
 )
 
 func main() {
 	cmd := commands.Setup(pkgName, version, commit)
 	cmd.SilenceUsage = true
 
+	if genDocs != "" {
+		if err := generateMarkdown(cmd); err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	if cmd.Execute() != nil {
 		os.Exit(1)
 	}
+}
+
+func generateCompletion(cmd *cobra.Command, docsPath string) error {
+	cmd.CompletionOptions.HiddenDefaultCmd = false
+	cmd.InitDefaultCompletionCmd()
+	completionCmd, _, err := cmd.Find([]string{"completion"})
+	if err != nil {
+		return err
+	}
+	mdFileFullPath := filepath.Join(docsPath, "nginx-meshctl_completion.md")
+
+	mdFile, err := os.Create(mdFileFullPath)
+	if err != nil {
+		return err
+	}
+	defer mdFile.Close()
+
+	caser := cases.Title(language.English)
+
+	scanner := bufio.NewScanner(strings.NewReader(completionCmd.UsageString()))
+	if _, err = mdFile.WriteString("## " + caser.String(completionCmd.Name()) + "\n"); err != nil {
+		return err
+	}
+
+	for scanner.Scan() {
+		line := strings.ReplaceAll(scanner.Text(), "ke.agarwal", "<user>")
+		if strings.Contains(line, "Usage:") {
+			_, err = mdFile.WriteString("```\n")
+		} else if strings.Contains(line, "Available Commands:") {
+			_, err = mdFile.WriteString("```\n### " + line + "\n```\n")
+		} else if strings.Contains(line, "Global Flags:") {
+			_, err = mdFile.WriteString("```\n### Options\n```\n")
+		} else if strings.Contains(line, "for more information about") {
+			_, err = mdFile.WriteString("```\n")
+		} else if len(line) > 0 {
+			_, err = mdFile.WriteString(line + "\n")
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func generateMarkdown(cmd *cobra.Command) error {
+	cmd.DisableAutoGenTag = true
+
+	// generates a markdown file for each CLI command
+	_, b, _, _ := runtime.Caller(0)
+	docsPath := filepath.Join(filepath.Dir(b), "../../docs/content/reference")
+	if err := doc.GenMarkdownTree(cmd, docsPath); err != nil {
+		return err
+	}
+
+	// combine all files in a buffer
+	buf := new(strings.Builder)
+	if err := generateCompletion(cmd, docsPath); err != nil {
+		log.Fatal(err)
+	}
+
+	docsFiles, err := os.ReadDir(docsPath)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range docsFiles {
+		if file.IsDir() || !strings.HasPrefix(file.Name(), "nginx-meshctl") {
+			continue
+		}
+
+		mdFileFullPath := filepath.Join(docsPath, file.Name())
+
+		var mdFile *os.File
+		mdFile, err = os.Open(mdFileFullPath)
+		if err != nil {
+			return err
+		}
+		defer mdFile.Close()
+
+		_, err = io.Copy(buf, mdFile)
+		if err != nil {
+			return err
+		}
+		if _, err = buf.WriteString("\n"); err != nil {
+			return err
+		}
+
+		if err = os.Remove(mdFileFullPath); err != nil {
+			return err
+		}
+	}
+
+	finalName := filepath.Join(docsPath, "nginx-meshctl.md")
+	finalFile, err := os.Create(finalName)
+	if err != nil {
+		return err
+	}
+	defer finalFile.Close()
+
+	if _, err := finalFile.WriteString(`---
+	title: CLI Reference
+	description: "Man page and instructions for using the NGINX Service Mesh CLI"
+	draft: false
+	weight: 300
+	toc: true
+	categories: ["reference"]
+	docs: "DOCS-704"
+	---
+`); err != nil {
+		return err
+	}
+
+	re := regexp.MustCompile("## nginx-meshctl ([a-z]+)")
+	caser := cases.Title(language.English)
+	scanner := bufio.NewScanner(strings.NewReader(buf.String()))
+	for scanner.Scan() {
+		line := strings.ReplaceAll(scanner.Text(), "ke.agarwal", "<user>")
+		if list := re.FindStringSubmatch(line); list != nil {
+			if _, err := finalFile.WriteString("## " + caser.String(list[len(list)-1]) + "\n"); err != nil {
+				return err
+			}
+			continue
+		}
+		// don't add cobra-generated footer
+		if !strings.Contains(line, "SEE ALSO") && !strings.Contains(line, "* [nginx-meshctl") {
+			if _, err := finalFile.WriteString(line + "\n"); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/docs/content/reference/nginx-meshctl.md
+++ b/docs/content/reference/nginx-meshctl.md
@@ -16,13 +16,13 @@ nginx-meshctl is the CLI utility for the NGINX Service Mesh control plane
 nginx-meshctl is the CLI utility for the NGINX Service Mesh control plane. 
 Requires a connection to a Kubernetes cluster via a kubeconfig.
 
-```
+```txt
 nginx-meshctl [flags]
 ```
 
 ### Options
 
-```
+```txt
   -h, --help                help for nginx-meshctl
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
@@ -33,18 +33,18 @@ nginx-meshctl [flags]
 
 
 ## Completion
-```
+```txt
   nginx-meshctl completion [command]
 ```
 ### Available Commands:
-```
+```txt
   bash        Generate the autocompletion script for bash
   fish        Generate the autocompletion script for fish
   powershell  Generate the autocompletion script for powershell
   zsh         Generate the autocompletion script for zsh
 ```
 ### Options
-```
+```txt
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
@@ -52,25 +52,26 @@ nginx-meshctl [flags]
 
 ## Config
 
+
 Display the NGINX Service Mesh configuration
 
 ### Synopsis
 
 Display the NGINX Service Mesh configuration.
 
-```
+```txt
 nginx-meshctl config [flags]
 ```
 
 ### Options
 
-```
+```txt
   -h, --help   help for config
 ```
 
 ### Options inherited from parent commands
 
-```
+```txt
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
@@ -80,6 +81,7 @@ nginx-meshctl config [flags]
 
 
 ## Deploy
+
 
 Deploys NGINX Service Mesh into your Kubernetes cluster
 
@@ -94,13 +96,13 @@ This command installs the following resources into your Kubernetes cluster by de
 
 
 
-```
+```txt
 nginx-meshctl deploy [flags]
 ```
 
 ### Examples
 
-```
+```txt
 
   Most of the examples below are abbreviated for convenience. The '...' in these 
   examples represents the image references. Be sure to include the image references 
@@ -130,7 +132,7 @@ nginx-meshctl deploy [flags]
 
 ### Options
 
-```
+```txt
       --access-control-mode string        default access control mode for service-to-service communication
                                           		Valid values: allow, deny (default "allow")
       --client-max-body-size string       NGINX client max body size (default "1m")
@@ -178,7 +180,7 @@ nginx-meshctl deploy [flags]
 
 ### Options inherited from parent commands
 
-```
+```txt
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
@@ -189,6 +191,7 @@ nginx-meshctl deploy [flags]
 
 ## Inject
 
+
 Inject the NGINX Service Mesh sidecars into Kubernetes resources
 
 ### Synopsis
@@ -197,13 +200,13 @@ Inject the NGINX Service Mesh sidecar into Kubernetes resources.
 - Accepts JSON and YAML formats.
 - Outputs JSON or YAML resources with injected sidecars to stdout.
 
-```
+```txt
 nginx-meshctl inject [flags]
 ```
 
 ### Examples
 
-```
+```txt
 
   - Inject the resources in my-app.yaml and create in Kubernetes:
 
@@ -225,7 +228,7 @@ nginx-meshctl inject [flags]
 
 ### Options
 
-```
+```txt
   -f, --file string                  the filename that contains the resources you want to inject
                                      		If no filename is provided, input will be taken from stdin
   -h, --help                         help for inject
@@ -235,7 +238,7 @@ nginx-meshctl inject [flags]
 
 ### Options inherited from parent commands
 
-```
+```txt
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
@@ -246,6 +249,7 @@ nginx-meshctl inject [flags]
 
 ## Remove
 
+
 Remove NGINX Service Mesh from your Kubernetes cluster
 
 ### Synopsis
@@ -255,13 +259,13 @@ Remove the NGINX Service Mesh from your Kubernetes cluster.
 - You will need to clean up all resources containing injected sidecar proxies manually.
 
 
-```
+```txt
 nginx-meshctl remove [flags]
 ```
 
 ### Examples
 
-```
+```txt
 
   - Remove the NGINX Service Mesh from the default namespace ('nginx-mesh'):
 		
@@ -279,14 +283,14 @@ nginx-meshctl remove [flags]
 
 ### Options
 
-```
+```txt
   -h, --help   help for remove
   -y, --yes    answer yes for confirmation of removal
 ```
 
 ### Options inherited from parent commands
 
-```
+```txt
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
@@ -297,6 +301,7 @@ nginx-meshctl remove [flags]
 
 ## Services
 
+
 List the Services registered with NGINX Service Mesh
 
 ### Synopsis
@@ -306,19 +311,19 @@ List the Services registered with NGINX Service Mesh.
 - The list contains only those Services whose Pods contain the NGINX Service Mesh sidecar.
 
 
-```
+```txt
 nginx-meshctl services [flags]
 ```
 
 ### Options
 
-```
+```txt
   -h, --help   help for services
 ```
 
 ### Options inherited from parent commands
 
-```
+```txt
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
@@ -329,25 +334,26 @@ nginx-meshctl services [flags]
 
 ## Status
 
+
 Check connection to NGINX Service Mesh
 
 ### Synopsis
 
 Check connection to NGINX Service Mesh.
 
-```
+```txt
 nginx-meshctl status [flags]
 ```
 
 ### Options
 
-```
+```txt
   -h, --help   help for status
 ```
 
 ### Options inherited from parent commands
 
-```
+```txt
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
@@ -358,19 +364,20 @@ nginx-meshctl status [flags]
 
 ## Supportpkg
 
+
 Create an NGINX Service Mesh support package
 
 ### Synopsis
 
 Create an NGINX Service Mesh support package.
 
-```
+```txt
 nginx-meshctl supportpkg [flags]
 ```
 
 ### Options
 
-```
+```txt
       --disable-sidecar-logs   disable the collection of sidecar logs
   -h, --help                   help for supportpkg
   -o, --output string          output directory for supportpkg tarball (default "/Users/<user>/NGINX/nginx-service-mesh")
@@ -378,7 +385,7 @@ nginx-meshctl supportpkg [flags]
 
 ### Options inherited from parent commands
 
-```
+```txt
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
@@ -389,6 +396,7 @@ nginx-meshctl supportpkg [flags]
 
 ## Top
 
+
 Display traffic statistics
 
 ### Synopsis
@@ -397,13 +405,13 @@ Display traffic statistics.
 Top provides information about the incoming and outgoing requests to and from a resource type or name.
 Supported resource types are: Pods, Deployments, StatefulSets, DaemonSets, and Namespaces.
 
-```
+```txt
 nginx-meshctl top [resource-type/resource] [flags]
 ```
 
 ### Examples
 
-```
+```txt
 
   - Display traffic statistics for all Deployments:
 		
@@ -420,14 +428,14 @@ nginx-meshctl top [resource-type/resource] [flags]
 
 ### Options
 
-```
+```txt
   -h, --help               help for top
   -n, --namespace string   namespace where the resource(s) resides (default "default")
 ```
 
 ### Options inherited from parent commands
 
-```
+```txt
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
 ```
@@ -436,6 +444,7 @@ nginx-meshctl top [resource-type/resource] [flags]
 
 
 ## Upgrade
+
 
 Upgrade NGINX Service Mesh
 
@@ -446,13 +455,13 @@ This command removes the existing NGINX Service Mesh while preserving user confi
 The latest version of NGINX Service Mesh is then deployed using that data.
 
 
-```
+```txt
 nginx-meshctl upgrade [flags]
 ```
 
 ### Options
 
-```
+```txt
   -h, --help                     help for upgrade
       --image-tag string         tag used for pulling images from registry
                                  		Affects: nginx-mesh-cert-reloader, nginx-mesh-controller, nginx-mesh-init, nginx-mesh-metrics, nginx-mesh-sidecar
@@ -464,7 +473,7 @@ nginx-meshctl upgrade [flags]
 
 ### Options inherited from parent commands
 
-```
+```txt
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
 ```
@@ -474,6 +483,7 @@ nginx-meshctl upgrade [flags]
 
 ## Version
 
+
 Display NGINX Service Mesh version
 
 ### Synopsis
@@ -481,19 +491,19 @@ Display NGINX Service Mesh version
 Display NGINX Service Mesh version.
 Will contact the mesh for version and timeout if unable to connect.
 
-```
+```txt
 nginx-meshctl version [flags]
 ```
 
 ### Options
 
-```
+```txt
   -h, --help   help for version
 ```
 
 ### Options inherited from parent commands
 
-```
+```txt
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)

--- a/docs/content/reference/nginx-meshctl.md
+++ b/docs/content/reference/nginx-meshctl.md
@@ -1,63 +1,50 @@
 ---
-title: CLI Reference
-description: "Man page and instructions for using the NGINX Service Mesh CLI"
-draft: false
-weight: 300
-toc: true
-categories: ["reference"]
-docs: "DOCS-704"
----
+	title: CLI Reference
+	description: "Man page and instructions for using the NGINX Service Mesh CLI"
+	draft: false
+	weight: 300
+	toc: true
+	categories: ["reference"]
+	docs: "DOCS-704"
+	---
+## nginx-meshctl
 
-## Usage
+nginx-meshctl is the CLI utility for the NGINX Service Mesh control plane
 
-`nginx-meshctl` is the CLI utility for the NGINX Service Mesh control plane.
-Requires a connection to a Kubernetes cluster via a `kubeconfig`.
+### Synopsis
 
-```txt
-Usage:
-  nginx-meshctl [flags]
-  nginx-meshctl [command]
+nginx-meshctl is the CLI utility for the NGINX Service Mesh control plane. 
+Requires a connection to a Kubernetes cluster via a kubeconfig.
 
-Available Commands:
-  completion  Generate the autocompletion script for the specified shell
-  config      Display the NGINX Service Mesh configuration
-  deploy      Deploys NGINX Service Mesh into your Kubernetes cluster
-  help        Help for nginx-meshctl or any command
-  inject      Inject the NGINX Service Mesh sidecars into Kubernetes resources
-  remove      Remove NGINX Service Mesh from your Kubernetes cluster
-  services    List the Services registered with NGINX Service Mesh
-  status      Check connection to NGINX Service Mesh API
-  supportpkg  Create an NGINX Service Mesh support package
-  top         Display traffic statistics
-  upgrade     Upgrade NGINX Service Mesh
-  version     Display NGINX Service Mesh version
+```
+nginx-meshctl [flags]
+```
 
-Flags:
+### Options
+
+```
   -h, --help                help for nginx-meshctl
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
 ```
 
+
+
+
 ## Completion
-
-Generate the autocompletion script for nginx-meshctl for the specified shell.
-See each sub-command's help for details on how to use the generated script.
-
-```txt
-Usage:
+```
   nginx-meshctl completion [command]
-
-Available Commands:
+```
+### Available Commands:
+```
   bash        Generate the autocompletion script for bash
   fish        Generate the autocompletion script for fish
   powershell  Generate the autocompletion script for powershell
   zsh         Generate the autocompletion script for zsh
-
-Flags:
-  -h, --help   help for completion
-
-Global Flags:
+```
+### Options
+```
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
@@ -65,38 +52,85 @@ Global Flags:
 
 ## Config
 
+Display the NGINX Service Mesh configuration
+
+### Synopsis
+
 Display the NGINX Service Mesh configuration.
 
-```txt
-Usage: 
-  nginx-meshctl config [flags]
+```
+nginx-meshctl config [flags]
+```
 
-Flags:
+### Options
+
+```
   -h, --help   help for config
+```
 
-Global Flags:
+### Options inherited from parent commands
+
+```
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
 ```
 
+
+
+
 ## Deploy
+
+Deploys NGINX Service Mesh into your Kubernetes cluster
+
+### Synopsis
 
 Deploy NGINX Service Mesh into your Kubernetes cluster.
 This command installs the following resources into your Kubernetes cluster by default:
-
-- NGINX Mesh API: The Control Plane for the Service Mesh.
+- NGINX Mesh Controller: The Control Plane for the Service Mesh.
 - NGINX Metrics API: SMI-formatted metrics.
 - SPIRE: mTLS service-to-service communication.
 - NATS: Message bus.
 
-<br>
 
-```txt
-Usage: 
-  nginx-meshctl deploy [flags]
 
-Flags:
+```
+nginx-meshctl deploy [flags]
+```
+
+### Examples
+
+```
+
+  Most of the examples below are abbreviated for convenience. The '...' in these 
+  examples represents the image references. Be sure to include the image references 
+  when running the deploy command.  
+	
+  - Deploy the latest version of NGINX Service Mesh, using default values, from your container registry:
+		
+      nginx-meshctl deploy --registry-server "registry:5000"
+	
+  - Deploy the Service Mesh in namespace "my-namespace":
+
+      nginx-meshctl deploy ... --namespace my-namespace
+
+  - Deploy the Service Mesh with mTLS turned off:
+
+      nginx-meshctl deploy ... --mtls-mode off
+
+  - Deploy the Service Mesh and enable telemetry traces to be exported to your OTLP gRPC collector running in your Kubernetes cluster:
+      
+      nginx-meshctl deploy ... --telemetry-exporters "type=otlp,host=otel-collector.my-namespace.svc.cluster.local,port=4317"
+
+  - Deploy the Service Mesh with upstream certificates and keys for mTLS:
+
+      nginx-meshctl deploy ... --mtls-upstream-ca-conf="disk.yaml"
+
+```
+
+### Options
+
+```
       --access-control-mode string        default access control mode for service-to-service communication
                                           		Valid values: allow, deny (default "allow")
       --client-max-body-size string       NGINX client max body size (default "1m")
@@ -106,7 +140,7 @@ Flags:
                                           		Valid values: kubernetes, openshift (default "kubernetes")
   -h, --help                              help for deploy
       --image-tag string                  tag used for pulling images from registry
-                                          		Affects: nginx-mesh-controller, nginx-mesh-cert-reloader, nginx-mesh-init, nginx-mesh-metrics, nginx-mesh-sidecar (default "2.0.0")
+                                          		Affects: nginx-mesh-cert-reloader, nginx-mesh-controller, nginx-mesh-init, nginx-mesh-metrics, nginx-mesh-sidecar (default "2.0.0")
       --mtls-ca-key-type string           the key type used for the SPIRE Server CA
                                           		Valid values: ec-p256, ec-p384, rsa-2048, rsa-4096 (default "ec-p256")
       --mtls-ca-ttl string                the CA/signing key TTL in hours(h). Min value 24h. Max value 999999h. (default "720h")
@@ -130,7 +164,7 @@ Flags:
       --registry-password string          password for accessing private registry
                                           		Requires --registry-username to be set. Cannot be used with --registry-key
       --registry-server string            hostname:port (if needed) for registry and path to images
-                                          		Affects: nginx-mesh-controller, nginx-mesh-cert-reloader, nginx-mesh-init, nginx-mesh-metrics, nginx-mesh-sidecar (default "docker-registry.nginx.com/nsm")
+                                          		Affects: nginx-mesh-cert-reloader, nginx-mesh-controller, nginx-mesh-init, nginx-mesh-metrics, nginx-mesh-sidecar (default "docker-registry.nginx.com/nsm")
       --registry-username string          username for accessing private registry
                                           		Requires --registry-password to be set. Cannot be used with --registry-key
       --spire-server-key-manager string   storage logic for SPIRE Server's private keys
@@ -140,244 +174,331 @@ Flags:
                                           		Type, host, and port are required. Only type "otlp" exporter is supported.
       --telemetry-sampler-ratio float32   the percentage of traces that are processed and exported to the telemetry backend.
                                           		Float between 0 and 1 (default 0.01)
+```
 
-Global Flags:
+### Options inherited from parent commands
+
+```
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
 ```
 
-### Deploy Examples
 
-Most of the examples below show shortened commands for convenience. The '...' in these examples represents the image references. Be sure to include the image references when running the deploy command.
 
-- Deploy the latest version of NGINX Service Mesh, using default values, from your container registry:
-
-    `nginx-meshctl deploy --registry-server "registry:5000"`
-
-- Deploy the Service Mesh in namespace "my-namespace":
-
-    `nginx-meshctl deploy ... --namespace my-namespace`
-
-- Deploy the Service Mesh with mTLS turned off:
-
-    `nginx-meshctl deploy ... --mtls-mode off`
-
-- Deploy the Service Mesh and enable telemetry traces to be exported to your OTLP gRPC collector running in your Kubernetes cluster:
-     
-    `nginx-meshctl deploy ... --telemetry-exporters "type=otlp,host=otel-collector.my-namespace.svc.cluster.local,port=4317"`
-
-- Deploy the Service Mesh with upstream certificates and keys for mTLS:
-
-    `nginx-meshctl deploy ... --mtls-upstream-ca-conf="disk.yaml"`
 
 ## Inject
 
-Inject the NGINX Service Mesh sidecar into Kubernetes resources.
+Inject the NGINX Service Mesh sidecars into Kubernetes resources
 
+### Synopsis
+
+Inject the NGINX Service Mesh sidecar into Kubernetes resources.
 - Accepts JSON and YAML formats.
 - Outputs JSON or YAML resources with injected sidecars to stdout.
 
-<br>
+```
+nginx-meshctl inject [flags]
+```
 
-```txt
-Usage: 
-  nginx-meshctl inject [flags]
+### Examples
 
-Flags:
+```
+
+  - Inject the resources in my-app.yaml and create in Kubernetes:
+
+      nginx-meshctl inject -f ./my-app.yaml | kubectl apply -f -
+
+  - Inject the resources passed into stdin and write the changes to the same file:
+
+      nginx-meshctl inject < ./my-app.json > ./my-injected-app.json
+
+  - Inject the resources in my-app.yaml and configure proxies to ignore ports 1433 and 1434 for outgoing traffic:
+
+      nginx-meshctl inject --ignore-outgoing-ports 1433,1434 -f ./my-app.yaml
+
+  - Inject the resources passed into stdin and configure proxies to ignore port 1433 for incoming traffic:
+
+      nginx-meshctl inject --ignore-incoming-ports 1433 < ./my-app.json 
+
+```
+
+### Options
+
+```
   -f, --file string                  the filename that contains the resources you want to inject
                                      		If no filename is provided, input will be taken from stdin
   -h, --help                         help for inject
       --ignore-incoming-ports ints   ports to ignore for incoming traffic
       --ignore-outgoing-ports ints   ports to ignore for outgoing traffic
+```
 
-Global Flags:
+### Options inherited from parent commands
+
+```
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
 ```
 
-### Inject Examples
 
-- Inject the resources in my-app.yaml and create in Kubernetes:
-  
-    `nginx-meshctl inject -f ./my-app.yaml | kubectl apply -f -`
 
-- Inject the resources passed into stdin and write the changes to the same file:
-
-    `nginx-meshctl inject < ./my-app.json > ./my-injected-app.json`
-
-- Inject the resources in my-app.yaml and configure proxies to ignore ports 1433 and 1434 for outgoing traffic:
-
-    `nginx-meshctl inject --ignore-outgoing-ports 1433,1434 -f ./my-app.yaml`
-
-- Inject the resources passed into stdin and configure proxies to ignore port 1433 for incoming traffic:
-
-    `nginx-meshctl inject --ignore-incoming-ports 1433 < ./my-app.json`
 
 ## Remove
 
+Remove NGINX Service Mesh from your Kubernetes cluster
+
+### Synopsis
+
 Remove the NGINX Service Mesh from your Kubernetes cluster.
+- Removes the resources created by the deploy command from the Service Mesh namespace (default: "nginx-mesh").
+- You will need to clean up all resources containing injected sidecar proxies manually.
 
-- Removes the resources created by the `deploy` command from the Service Mesh namespace (default: "nginx-mesh").
-- You will need to clean up all Deployments with injected proxies manually.
 
-<br>
+```
+nginx-meshctl remove [flags]
+```
 
-```txt
-Usage: 
-  nginx-meshctl remove [flags]
+### Examples
 
-Flags:
-      --environment string   environment the mesh is deployed in
-                             		Valid values: kubernetes, openshift
-  -h, --help                 help for remove
-  -y, --yes                  answer yes for confirmation of removal
+```
 
-Global Flags:
+  - Remove the NGINX Service Mesh from the default namespace ('nginx-mesh'):
+		
+      nginx-meshctl remove
+	
+  - Remove the NGINX Service Mesh from namespace 'my-namespace':
+		
+      nginx-meshctl remove --namespace my-namespace
+		
+  - Remove the NGINX Service Mesh without prompting the user to confirm removal:
+	
+      nginx-meshctl remove -y
+
+```
+
+### Options
+
+```
+  -h, --help   help for remove
+  -y, --yes    answer yes for confirmation of removal
+```
+
+### Options inherited from parent commands
+
+```
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
 ```
 
-### Remove Examples
 
-- Remove the NGINX Service Mesh from the default namespace ("nginx-mesh"):
 
-    `nginx-meshctl remove`
-
-- Remove the NGINX Service Mesh from namespace "my-namespace":
-
-    `nginx-meshctl remove --namespace my-namespace`
-
-- Remove the NGINX Service Mesh without prompting the user to confirm removal:
-
-    `nginx-meshctl remove -y`
 
 ## Services
 
-List the Services registered with NGINX Service Mesh.
+List the Services registered with NGINX Service Mesh
 
+### Synopsis
+
+List the Services registered with NGINX Service Mesh.
 - Outputs the Services and their upstream addresses and ports.
 - The list contains only those Services whose Pods contain the NGINX Service Mesh sidecar.
 
-<br>
 
-```txt
-Usage: 
-  nginx-meshctl services [flags]
+```
+nginx-meshctl services [flags]
+```
 
-Flags:
+### Options
+
+```
   -h, --help   help for services
+```
 
-Global Flags:
+### Options inherited from parent commands
+
+```
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
 ```
+
+
+
 
 ## Status
 
-Check connection to NGINX Service Mesh API.
+Check connection to NGINX Service Mesh
 
-```txt
-Usage:
-  nginx-meshctl status [flags]
+### Synopsis
 
-Flags:
+Check connection to NGINX Service Mesh.
+
+```
+nginx-meshctl status [flags]
+```
+
+### Options
+
+```
   -h, --help   help for status
+```
 
-Global Flags:
+### Options inherited from parent commands
+
+```
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
 ```
+
+
+
 
 ## Supportpkg
 
+Create an NGINX Service Mesh support package
+
+### Synopsis
+
 Create an NGINX Service Mesh support package.
 
-```txt
-Usage:
-  nginx-meshctl supportpkg [flags]
+```
+nginx-meshctl supportpkg [flags]
+```
 
-Flags:
+### Options
+
+```
       --disable-sidecar-logs   disable the collection of sidecar logs
   -h, --help                   help for supportpkg
-  -o, --output string          output directory for supportpkg tarball (default "$PWD")
+  -o, --output string          output directory for supportpkg tarball (default "/Users/<user>/NGINX/nginx-service-mesh")
+```
 
-Global Flags:
+### Options inherited from parent commands
+
+```
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
 ```
 
+
+
+
 ## Top
+
+Display traffic statistics
+
+### Synopsis
 
 Display traffic statistics.
 Top provides information about the incoming and outgoing requests to and from a resource type or name.
 Supported resource types are: Pods, Deployments, StatefulSets, DaemonSets, and Namespaces.
 
-```txt
-Usage:
-  nginx-meshctl top [resource-type/resource] [flags]
-
-Flags:
-  -h, --help   help for top
-  -n, --namespace string   namespace where the resource(s) resides (default "default")
-
-Global Flags:
-  -k, --kubeconfig string  path to kubectl config file (default "/Users/<user>/.kube/config")
+```
+nginx-meshctl top [resource-type/resource] [flags]
 ```
 
-### Top Examples
+### Examples
 
-- Display traffic statistics for all Deployments:
+```
 
-    `nginx-meshctl top`
+  - Display traffic statistics for all Deployments:
+		
+      nginx-meshctl top
+  
+  - Display traffic statistics for all Pods:
+		
+      nginx-meshctl top pods
+  
+  - Display traffic statistics for Deployment "my-app":
+	 
+      nginx-meshctl top deployments/my-app
+```
 
-- Display traffic statistics for all Pods:
+### Options
 
-    `nginx-meshctl top pods`
+```
+  -h, --help               help for top
+  -n, --namespace string   namespace where the resource(s) resides (default "default")
+```
 
-- Display traffic statistics for Deployment "my-app":
+### Options inherited from parent commands
 
-    `nginx-meshctl top deployments/my-app`
+```
+  -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
+  -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
+```
+
+
+
 
 ## Upgrade
+
+Upgrade NGINX Service Mesh
+
+### Synopsis
 
 Upgrade NGINX Service Mesh to the latest version.
 This command removes the existing NGINX Service Mesh while preserving user configuration data.
 The latest version of NGINX Service Mesh is then deployed using that data.
 
-```txt
-Usage:
-  nginx-meshctl upgrade [flags]
 
-Flags:
-  -h, --help   help for upgrade
-  -y, --yes    answer yes for confirmation of upgrade
-  -t, --timeout duration   timeout when waiting for an upgrade to finish (default 5m0s)
+```
+nginx-meshctl upgrade [flags]
+```
 
-Global Flags:
+### Options
+
+```
+  -h, --help                     help for upgrade
+      --image-tag string         tag used for pulling images from registry
+                                 		Affects: nginx-mesh-cert-reloader, nginx-mesh-controller, nginx-mesh-init, nginx-mesh-metrics, nginx-mesh-sidecar
+      --registry-server string   hostname:port (if needed) for registry and path to images
+                                 		Affects: nginx-mesh-cert-reloader, nginx-mesh-controller, nginx-mesh-init, nginx-mesh-metrics, nginx-mesh-sidecar
+  -t, --timeout duration         timeout when waiting for an upgrade to finish (default 5m0s)
+  -y, --yes                      answer yes for confirmation of upgrade
+```
+
+### Options inherited from parent commands
+
+```
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
 ```
 
+
+
+
 ## Version
 
+Display NGINX Service Mesh version
+
+### Synopsis
+
 Display NGINX Service Mesh version.
-Will contact Mesh API Server for version and timeout if unable to connect.
+Will contact the mesh for version and timeout if unable to connect.
 
-```txt
-Usage:
-  nginx-meshctl version [flags]
+```
+nginx-meshctl version [flags]
+```
 
-Flags:
+### Options
+
+```
   -h, --help   help for version
+```
 
-Global Flags:
+### Options inherited from parent commands
+
+```
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
   -t, --timeout duration    timeout when communicating with NGINX Service Mesh (default 5s)
 ```
+
+
+
+

--- a/docs/content/reference/nginx-meshctl.md
+++ b/docs/content/reference/nginx-meshctl.md
@@ -37,6 +37,7 @@ nginx-meshctl [flags]
 ```txt
   nginx-meshctl completion [command]
 ```
+
 ### Available Commands
 
 ```txt
@@ -45,6 +46,7 @@ nginx-meshctl [flags]
   powershell  Generate the autocompletion script for powershell
   zsh         Generate the autocompletion script for zsh
 ```
+
 ### Options
 
 ```txt
@@ -201,6 +203,7 @@ Inject the NGINX Service Mesh sidecars into Kubernetes resources
 ### Synopsis
 
 Inject the NGINX Service Mesh sidecar into Kubernetes resources.
+
 - Accepts JSON and YAML formats.
 - Outputs JSON or YAML resources with injected sidecars to stdout.
 
@@ -259,6 +262,7 @@ Remove NGINX Service Mesh from your Kubernetes cluster
 ### Synopsis
 
 Remove the NGINX Service Mesh from your Kubernetes cluster.
+
 - Removes the resources created by the deploy command from the Service Mesh namespace (default: "nginx-mesh").
 - You will need to clean up all resources containing injected sidecar proxies manually.
 
@@ -311,6 +315,7 @@ List the Services registered with NGINX Service Mesh
 ### Synopsis
 
 List the Services registered with NGINX Service Mesh.
+
 - Outputs the Services and their upstream addresses and ports.
 - The list contains only those Services whose Pods contain the NGINX Service Mesh sidecar.
 

--- a/docs/content/reference/nginx-meshctl.md
+++ b/docs/content/reference/nginx-meshctl.md
@@ -33,10 +33,12 @@ nginx-meshctl [flags]
 
 
 ## Completion
+
 ```txt
   nginx-meshctl completion [command]
 ```
-### Available Commands:
+### Available Commands
+
 ```txt
   bash        Generate the autocompletion script for bash
   fish        Generate the autocompletion script for fish
@@ -44,6 +46,7 @@ nginx-meshctl [flags]
   zsh         Generate the autocompletion script for zsh
 ```
 ### Options
+
 ```txt
   -k, --kubeconfig string   path to kubectl config file (default "/Users/<user>/.kube/config")
   -n, --namespace string    NGINX Service Mesh control plane namespace (default "nginx-mesh")
@@ -89,6 +92,7 @@ Deploys NGINX Service Mesh into your Kubernetes cluster
 
 Deploy NGINX Service Mesh into your Kubernetes cluster.
 This command installs the following resources into your Kubernetes cluster by default:
+
 - NGINX Mesh Controller: The Control Plane for the Service Mesh.
 - NGINX Metrics API: SMI-formatted metrics.
 - SPIRE: mTLS service-to-service communication.

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/containerd/containerd v1.7.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v20.10.21+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -249,6 +249,7 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/nginx-meshctl/commands/deploy.go
+++ b/internal/nginx-meshctl/commands/deploy.go
@@ -37,6 +37,7 @@ const (
 
 	longDeploy = `Deploy NGINX Service Mesh into your Kubernetes cluster.
 This command installs the following resources into your Kubernetes cluster by default:
+
 - NGINX Mesh Controller: The Control Plane for the Service Mesh.
 - NGINX Metrics API: SMI-formatted metrics.
 - SPIRE: mTLS service-to-service communication.

--- a/internal/nginx-meshctl/commands/inject.go
+++ b/internal/nginx-meshctl/commands/inject.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	longInject = `Inject the NGINX Service Mesh sidecar into Kubernetes resources.
+
 - Accepts JSON and YAML formats.
 - Outputs JSON or YAML resources with injected sidecars to stdout.`
 

--- a/internal/nginx-meshctl/commands/remove.go
+++ b/internal/nginx-meshctl/commands/remove.go
@@ -22,6 +22,7 @@ import (
 )
 
 const longRemove = `Remove the NGINX Service Mesh from your Kubernetes cluster.
+
 - Removes the resources created by the deploy command from the Service Mesh namespace (default: "nginx-mesh").
 - You will need to clean up all resources containing injected sidecar proxies manually.
 `

--- a/internal/nginx-meshctl/commands/services.go
+++ b/internal/nginx-meshctl/commands/services.go
@@ -15,6 +15,7 @@ import (
 )
 
 const longServices = `List the Services registered with NGINX Service Mesh.
+
 - Outputs the Services and their upstream addresses and ports.
 - The list contains only those Services whose Pods contain the NGINX Service Mesh sidecar.
 `

--- a/internal/nginx-meshctl/commands/top.go
+++ b/internal/nginx-meshctl/commands/top.go
@@ -10,7 +10,6 @@ import (
 	aggregator "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 
 	"github.com/nginxinc/nginx-service-mesh/internal/nginx-meshctl/top"
-	"github.com/nginxinc/nginx-service-mesh/pkg/k8s"
 )
 
 const (
@@ -134,34 +133,6 @@ func Top() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "namespace where the resource(s) resides")
-	cmd.SetUsageTemplate(topTemplate)
 
 	return cmd
 }
-
-// Custom template for TOP to fix the namespace usage statement (default template shows parent usage).
-var topTemplate = fmt.Sprintf(`Usage:{{if .Runnable}}
-  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
-
-Aliases:
-  {{.NameAndAliases}}{{end}}{{if .HasExample}}
-
-Examples:
-{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
-
-Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
-
-Flags:
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}
-  -n, --namespace string   namespace where the resource(s) resides (default "default")
-
-Global Flags:
-  -k, --kubeconfig string   path to kubectl config file (default "%s"){{if .HasHelpSubCommands}}
-
-Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
-
-Use "{{.CommandPath}} [command] --help"  or "{{.CommandPath}} help [command]" for more information about a command.{{end}}
-`, k8s.GetKubeConfig())

--- a/internal/nginx-meshctl/commands/upgrade.go
+++ b/internal/nginx-meshctl/commands/upgrade.go
@@ -130,8 +130,6 @@ func Upgrade(version string) *cobra.Command {
 		fmt.Println("error marking flag as hidden: ", err)
 	}
 
-	cmd.SetUsageTemplate(upgradeTemplate)
-
 	return cmd
 }
 
@@ -152,34 +150,6 @@ func loopImageErrorCheck(k8sClient k8s.Client, done chan struct{}) {
 		}
 	}
 }
-
-// Custom template for Upgrade to fix the timeout usage statement (default template shows parent usage).
-var upgradeTemplate = fmt.Sprintf(`Usage:{{if .Runnable}}
-  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
-
-Aliases:
-  {{.NameAndAliases}}{{end}}{{if .HasExample}}
-
-Examples:
-{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
-
-Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
-
-Flags:
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}
-  -t, --timeout duration   timeout when waiting for an upgrade to finish (default 5m0s)
-
-Global Flags:
-  -k, --kubeconfig string   path to kubectl config file (default "%s")
-  -n, --namespace string    NGINX Service Mesh control plane namespace (default "%s"){{if .HasHelpSubCommands}}
-
-Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
-
-Use "{{.CommandPath}} [command] --help"  or "{{.CommandPath}} help [command]" for more information about a command.{{end}}
-`, k8s.GetKubeConfig(), meshNamespace)
 
 type upgrader struct {
 	k8sClient k8s.Client


### PR DESCRIPTION
### Proposed changes
- Added  auto-generation for CLI documentation from Go code. A new command has been added to the `make generate` rule which autogenerates the documentation. 
- You can also run `go run -ldflags '-X main.genDocs=true' cmd/nginx-meshctl/main.go > /dev/null` to just generate the documentation.
- Removed UsageTemplates from `top.go` and `upgrade.go` since they were printing out some flags redundantly.  

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
