### PR TITLE
Upgrade nginx-hugo-theme to support newer Hugo versions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,11 +8,11 @@ Docs are written in Markdown. We build the docs using [Hugo](https://gohugo.io) 
 
 1. To install Hugo locally, refer to the [Hugo installation instructions](https://gohugo.io/getting-started/installing/).
 
-    > **NOTE**: We don't support versions newer than v0.91 yet.
+    > **NOTE**: We are currently running [Hugo v0.115.3](https://github.com/gohugoio/hugo/releases/tag/v0.115.3) in production.
 
 2. We use markdownlint to check that Markdown files are correct. Use `npm` to install markdownlint-cli:
 
-    ```
+    ```shell
     npm install -g markdownlint-cli   
     ```
 
@@ -77,6 +77,21 @@ For example:
 ```md
 To install <product>, refer to the [installation instructions]({{< ref "install" >}}).
 ```
+
+### How to include images
+
+You can use the `img` [shortcode](#how-to-use-hugo-shortcodes) to add images into your documentation.
+
+1. Add the image to the static/img directory, or to the same directory as the doc you want to use it in.
+
+   **DO NOT include a forward slash at the beginning of the file path.** This will break the image when it's rendered.
+   See the docs for the [Hugo relURL Function](https://gohugo.io/functions/relurl/#input-begins-with-a-slash) to learn more.
+
+1. Add the img shortcode:
+
+   `{{< img src="<img-file.png>" >}}`
+
+> Note: The shortcode accepts all of the same parameters as the [Hugo figure shortcode](https://gohugo.io/content-management/shortcodes/#figure).
 
 ### How to use Hugo shortcodes
 

--- a/docs/content/about/architecture.md
+++ b/docs/content/about/architecture.md
@@ -17,7 +17,7 @@ NGINX Service Mesh deploys two primary layers: a **control plane layer** that's 
 
 The control plane comprises multiple subsystems, each of which is explained below. Following the sidecar pattern, data plane elements replicate throughout the application in a 1:1 ratio with application workloads. Each data plane element is an identical instance using configuration data to shape its behavior and customize its relative position within the application topology.
 
-{{< img src="/img/architecture.png" alt="NGINX Service Mesh Architecture" >}}
+{{< img src="img/architecture.png" alt="NGINX Service Mesh Architecture" >}}
 *NGINX Service Mesh Architecture*
 
 ### NGINX Service Mesh Controllers
@@ -71,7 +71,7 @@ Once the sidecar receives traffic, it's able to do its work. For example, if mTL
 
 This section steps through some packet flow examples using the following diagram.
 
-{{< img src="/img/networking.png" alt="NGINX Service Mesh Networking Diagram">}}
+{{< img src="img/networking.png" alt="NGINX Service Mesh Networking Diagram">}}
 *NGINX Service Mesh Network Example*
 
 Key Concepts:
@@ -111,7 +111,7 @@ Use cases for eBPF include tracing, monitoring, and profiling. In NGINX Service 
 
 See the flow of a packet from generation to delivery to destination.
 
-{{< img src="/img/udp-egress.jpeg" alt="NGINX Service Mesh UDP Egress Networking Diagram" width="75%" >}}
+{{< img src="img/udp-egress.jpeg" alt="NGINX Service Mesh UDP Egress Networking Diagram" width="75%" >}}
 
 Here you can see the flow of a packet from generation by the workload to delivery to the destination workload. This diagram has abstracted away the destination pod networking specifics since that is covered in the above diagram.
 
@@ -127,7 +127,7 @@ The packet flows through the TC egress filter set up by the init container into 
 
 This section talks about the specifics of UDP networking for outgoing traffic.
 
-{{< img src="/img/udp-ingress.jpeg" alt="NGINX Service Mesh UDP Ingress Networking Diagram" width="75%" >}}
+{{< img src="img/udp-ingress.jpeg" alt="NGINX Service Mesh UDP Ingress Networking Diagram" width="75%" >}}
 
 The diagram shows that the source of the packet is coming from an external source workload. Once the packet finds its way into the network namespace of the destination pod, the `XDP` eBPF hook triggers the execution of the custom eBPF program. This redirects the packet to the proxy container, rather than the workload itself while using the same PROXY protocol V2 header to maintain original destination information.
 
@@ -145,7 +145,7 @@ NGINX Service Mesh uses mutual TLS (mTLS) to encrypt and authenticate data sent 
 
 NGINX Service Mesh integrates [SPIRE](https://github.com/spiffe/spire) as its central Certificate Authority (CA). SPIRE handles the entire lifecycle of the certificate: creation, distribution, and rotation. NGINX Plus uses SPIRE-issued certificates to establish mTLS sessions and encrypt traffic.
 
-{{< img src="/img/mtls.png" alt="NGINX Service Mesh mTLS Architecture Diagram">}}
+{{< img src="img/mtls.png" alt="NGINX Service Mesh mTLS Architecture Diagram">}}
 *NGINX Service Mesh mTLS Architecture*
 
 The important components in the diagram are:
@@ -267,7 +267,7 @@ See the [Traffic Metrics]({{< ref "/guides/smi-traffic-metrics.md" >}}) guide fo
 
 Here is an example of the tracing data flow using both DataDog and LightStep as the final collectors:
 
-{{< img src="/img/opentelemetry.png" alt="OpenTelemetry Data Flow" >}}
+{{< img src="img/opentelemetry.png" alt="OpenTelemetry Data Flow" >}}
 *Tracing data flow using the OpenTelemetry Collector*
 
 ### Ingress and Egress Traffic

--- a/docs/content/guides/monitoring-and-tracing.md
+++ b/docs/content/guides/monitoring-and-tracing.md
@@ -106,5 +106,5 @@ Tracing relies on the trace headers passed through each microservice in an appli
 
 If configured correctly, tracing data that is generated or propagated by the NGINX Service Mesh sidecar will be exported to the OTEL Collector, and then exported to the upstream collector(s), as shown in the following example diagram:
 
-{{< img src="/img/opentelemetry.png" alt="OpenTelemetry Data Flow" >}}
+{{< img src="img/opentelemetry.png" alt="OpenTelemetry Data Flow" >}}
 *Tracing data flow using the OpenTelemetry Collector*

--- a/docs/content/releases/release-notes-1.0.0.md
+++ b/docs/content/releases/release-notes-1.0.0.md
@@ -212,8 +212,8 @@ There is no workaround at this time, but the configuration can be changed dynami
 
 To fix the issue, take one or more of the following actions:
 
-- All load balancing annotations (config.nsm.nginx.com/lb-method) should be removed or updated to another supported algorithm (see [https://docs.nginx.com/nginx-service-mesh/get-started/configuration/](https://docs.nginx.com/nginx-service-mesh/get-started/configuration/)).
-- The global load balancing algorithm should be set to another supported algorithm (see [https://docs.nginx.com/nginx-service-mesh/get-started/configuration/](https://docs.nginx.com/nginx-service-mesh/get-started/configuration/)) .
+- All load balancing annotations (config.nsm.nginx.com/lb-method) should be removed or updated to another supported algorithm.
+- The global load balancing algorithm should be set to another supported algorithm.
   <br/><br/>
 
 

--- a/docs/content/releases/release-notes-1.1.0.md
+++ b/docs/content/releases/release-notes-1.1.0.md
@@ -223,8 +223,8 @@ There is no workaround at this time, but the configuration can be changed dynami
 
 To fix the issue, take one or more of the following actions:
 
-- All load balancing annotations (config.nsm.nginx.com/lb-method) should be removed or updated to another supported algorithm (see [https://docs.nginx.com/nginx-service-mesh/get-started/configuration/](https://docs.nginx.com/nginx-service-mesh/get-started/configuration/)).
-- The global load balancing algorithm should be set to another supported algorithm (see [https://docs.nginx.com/nginx-service-mesh/get-started/configuration/](https://docs.nginx.com/nginx-service-mesh/get-started/configuration/)) .
+- All load balancing annotations (config.nsm.nginx.com/lb-method) should be removed or updated to another supported algorithm.
+- The global load balancing algorithm should be set to another supported algorithm.
   <br/><br/>
 
 

--- a/docs/content/tutorials/kic/deploy-with-kic.md
+++ b/docs/content/tutorials/kic/deploy-with-kic.md
@@ -386,7 +386,7 @@ Then you can navigate your browser to `localhost:3000` to view Grafana.
 
 Here is a view of the provided "NGINX Mesh Top" dashboard:
 
-{{< img src="/img/grafana.png" >}}
+{{< img src="img/grafana.png" >}}
 
 ## How NGINX Ingress Controller Integrates with NGINX Service Mesh
 

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,6 +2,4 @@ module github.com/nginxinc/nginx-service-mesh/docs
 
 go 1.19
 
-require (
-	github.com/nginxinc/nginx-hugo-theme v0.33.0 // indirect
-)
+require github.com/nginxinc/nginx-hugo-theme v0.34.0 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,6 @@
 github.com/nginxinc/nginx-hugo-theme v0.28.0 h1:RHHvBmFk2Uptk+efLPSIuBd2elc3IOZPElkJbkkpAHo=
 github.com/nginxinc/nginx-hugo-theme v0.28.0/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
+github.com/nginxinc/nginx-hugo-theme v0.33.0 h1:6mZdgxf5kNhInsrAXXiSlWXRy3fsP51lWKOdrvmkR6U=
+github.com/nginxinc/nginx-hugo-theme v0.33.0/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
+github.com/nginxinc/nginx-hugo-theme v0.34.0 h1:G7LPVq7w1ls6IS4+OkTwjhFb67rLCzPdfZvW1/sn2Cw=
+github.com/nginxinc/nginx-hugo-theme v0.34.0/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=


### PR DESCRIPTION
### Proposed changes

This PR updates the nginx-hugo-theme module to v0.34.0, which adds support for Hugo v0.115.3 (and subsequent newer releases). This upgrade is necessary to address security vulnerabilities in the earlier pinned version of Hugo.

- I have corrected instances of the `img` shortcode where a leading slash was used in the file path, ensuring that the images will render properly in the built documentation. 
- The docs/README has been updated to match that used across the NGINX projects where we develop docs.
- The docs/makefile, netlify configs, and hugo configs have all been updated so they are also now in parity with the configurations used across the NGINX documentation projects.

Related PR: https://github.com/nginxinc/nginx-hugo-theme/pull/16

Once this PR is merged, the environment variables that are stored in Netlify for the nginx-hugo-theme version and hugo version will be updated accordingly.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
