### PR TITLE
fix: bump hugo theme to 0.35.0

### DIFF
--- a/docs/config/_default/config.toml
+++ b/docs/config/_default/config.toml
@@ -8,6 +8,8 @@ description = "NGINX Service Mesh provides secure, service-to-service management
 refLinksErrorLevel = "ERROR"
 enableRobotsTXT = "true"
 #canonifyURLs = true
+pygmentsCodeFences = true
+pygmentsUseClasses = true
 
 [caches]
   [caches.modules]

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,4 @@ module github.com/nginxinc/nginx-service-mesh/docs
 
 go 1.19
 
-require github.com/nginxinc/nginx-hugo-theme v0.34.0 // indirect
+require github.com/nginxinc/nginx-hugo-theme v0.35.0 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -4,3 +4,5 @@ github.com/nginxinc/nginx-hugo-theme v0.33.0 h1:6mZdgxf5kNhInsrAXXiSlWXRy3fsP51l
 github.com/nginxinc/nginx-hugo-theme v0.33.0/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
 github.com/nginxinc/nginx-hugo-theme v0.34.0 h1:G7LPVq7w1ls6IS4+OkTwjhFb67rLCzPdfZvW1/sn2Cw=
 github.com/nginxinc/nginx-hugo-theme v0.34.0/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
+github.com/nginxinc/nginx-hugo-theme v0.35.0 h1:7XB2GMy6qeJgKEJy9wOS3SYKYpfvLW3/H+UHRPLM4FU=
+github.com/nginxinc/nginx-hugo-theme v0.35.0/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=


### PR DESCRIPTION
### Proposed changes
Cherrypick f64c8a4e63a5ce0f62b23faf74ee605e9f44816c to release branch

Update hugo theme to 0.35.0
Update code block highlight color choice. Fixes accessibility issues.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
